### PR TITLE
Correct wording on Edge Login and fix missing image

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -681,7 +681,7 @@ const strings = {
   error_disabling_recovery: 'Error disabling recovery',
   recovery_disabled: 'Recovery Disabled',
   edge_login: 'Edge Login',
-  edge_description: 'This application would like to access the following repositories linked to your Airbitz account. It will not have access to any other accounts or wallets.',
+  edge_description: 'This application would like to create or access its wallet in your Edge account.\n\n It will not have access to any other wallets.',
   bitid_identity: 'BitID Identity',
   provide_an_identity_token: 'Provide an Identity Token',
   invalid_edge_login_request: 'Invalid Edge Login Request',

--- a/src/styles/scenes/EdgeLoginSceneStyle.js
+++ b/src/styles/scenes/EdgeLoginSceneStyle.js
@@ -19,6 +19,10 @@ const EdgeLoginScreen = {
     justifyContent: 'space-around'
 
   },
+  image: {
+    width: 70,
+    height: 70
+  },
   headerTextRow: {
     flex: 3,
     alignItems: 'center',


### PR DESCRIPTION
Image components from remote hosts need explicit sizing. This also required changing the server side images on info1.edgesecure.co since remote images can't be easily proportionally scaled.