### PR TITLE
Implement external browser for helpModal (modified) links

### DIFF
--- a/src/html/enUS/info.html
+++ b/src/html/enUS/info.html
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<title>Airbitz Info</title>
+<title>Edge Info</title>
 <style type="text/css">
 a:link {
     text-decoration: none;
@@ -23,10 +23,9 @@ a:link {
   <BR />
   <strong>Contact Support</strong><BR />
   <a href="mailto:support@edgesecure.co">support@edgesecure.co</a><BR />
-  <a href="tel:+1-844-928-9744">+1-844-928-9744</a><BR />
-  <a href="https://telegram.airbitz.co">Telegram</a><BR />
-  <a href="https://www.airbitz.slack.com">Slack</a><BR />
-  <a href="https://whatsapp.airbitz.co">WhatsApp</a><BR />
+  <a href="tel:+1-855-346-4974">+1-855-346-4974</a><BR />
+  <a href="https://t.me/joinchat/AAAAAEG4wXOcIlHhXL2Now">Telegram</a><BR />
+  <a href="https://chat.whatsapp.com/invite/3N9zE4bCaBP1tjIYUW3QVj">WhatsApp</a><BR />
 
 </div>
 </body>

--- a/src/modules/UI/components/HelpModal/HelpModal.ui.js
+++ b/src/modules/UI/components/HelpModal/HelpModal.ui.js
@@ -31,7 +31,7 @@ export default class HelpModal extends Component {
         visibilityBoolean={this.props.modal}
         onExitButtonFxn={this.props.closeModal}
         headerText='help_modal_title'
-        modalMiddle={<WebView ref={(ref) => { this.webview = ref }}scalesPageToFit={false} style={{justifyContent: 'center', alignItems:'center', height: 240, flex: 1}} source={HTML}
+        modalMiddle={<WebView ref={(ref) => { this.webview = ref }} scalesPageToFit={false} style={{justifyContent: 'center', alignItems:'center', height: 240, flex: 1}} source={HTML}
           onNavigationStateChange={(event) => {
             if (!event.url.includes('assets/src/html/enUS/info.html')) {
               console.log('event is: ', event)

--- a/src/modules/UI/components/HelpModal/HelpModal.ui.js
+++ b/src/modules/UI/components/HelpModal/HelpModal.ui.js
@@ -3,7 +3,8 @@ import {
   View,
   Image,
   WebView,
-  Text
+  Text,
+  Linking
 } from 'react-native'
 import strings from '../../../../locales/default'
 import styles from './style.js'
@@ -30,7 +31,14 @@ export default class HelpModal extends Component {
         visibilityBoolean={this.props.modal}
         onExitButtonFxn={this.props.closeModal}
         headerText='help_modal_title'
-        modalMiddle={<WebView scalesPageToFit={false} style={{justifyContent: 'center', alignItems:'center', height: 240, flex: 1}} source={HTML} />}
+        modalMiddle={<WebView ref={(ref) => { this.webview = ref }}scalesPageToFit={false} style={{justifyContent: 'center', alignItems:'center', height: 240, flex: 1}} source={HTML}
+          onNavigationStateChange={(event) => {
+            if (!event.url.includes('assets/src/html/enUS/info.html')) {
+              console.log('event is: ', event)
+              this.webview.stopLoading()
+              Linking.openURL(event.url)
+            }
+          }} />}
         modalBottom={<View style={[styles.modalBottomContainer]}>
                         <Text style={styles.modalBottomText}>{strings.enUS['help_version']} {versionNumber}</Text>
                         <Text style={styles.modalBottomText}>{strings.enUS['help_build']} {buildNumber}</Text>


### PR DESCRIPTION
The purpose of this pull request is to cause links within the helpModal to be opened by an *external* browser. Additionally, I have updated the contact info phone number and links to reflect new branding.

Asana task for external browser bug: https://app.asana.com/0/361770107085503/317312547827494/f
Asana task for updated contact info: https://app.asana.com/0/361770107085503/463937108594899/f
