### PR TITLE
Enlarge crypto logos on walletList(s)

### DIFF
--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
@@ -91,7 +91,7 @@ class FullWalletListRow extends Component<Props, State> {
                 <View style={[styles.rowNameTextWrap, b()]}>
                   <T style={[styles.rowNameText, b()]} numberOfLines={1}>
                   {symbolImageDarkMono
-                    && <Image style={[styles.rowCurrencyLogo, b()]} transform={[{translateY: 2}]} source={{uri: symbolImageDarkMono}} resizeMode='cover' />
+                    && <Image style={[styles.rowCurrencyLogo, b()]} transform={[{translateY: 6}]} source={{uri: symbolImageDarkMono}} resizeMode='cover' />
                   }  {cutOffText(name, 34)}</T>
                 </View>
                 <View style={[styles.rowBalanceTextWrap]}>

--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/SortableWalletListRow.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/SortableWalletListRow.ui.js
@@ -44,7 +44,7 @@ class SortableWalletListRow extends Component<Props, State> {
               <View style={[styles.rowNameTextWrap]}>
                 <T style={[styles.rowNameText]} numberOfLines={1}>
                   {symbolImageDarkMono
-                    && <Image style={[styles.rowCurrencyLogo, b()]} transform={[{translateY: 2}]} source={{uri: symbolImageDarkMono}} resizeMode='cover' />
+                    && <Image style={[styles.rowCurrencyLogo, b()]} transform={[{translateY: 5}]} source={{uri: symbolImageDarkMono}} resizeMode='cover' />
                   }  {cutOffText(name, 34)}
                 </T>
               </View>

--- a/src/modules/UI/scenes/WalletList/style.js
+++ b/src/modules/UI/scenes/WalletList/style.js
@@ -182,8 +182,8 @@ export const styles = {
     marginRight: 5
   },
   rowCurrencyLogo: {
-    height: 14,
-    width: 14,
+    height: 22,
+    width: 22,
     resizeMode: Image.resizeMode.contain,
     alignSelf: 'center'
   },


### PR DESCRIPTION
The purpose of this task is to increase the size of the cryptocurrency logos on the walletList scene (for both the full list and sort list).

Asana Task: https://app.asana.com/0/361770107085503/459375388568101/f