### PR TITLE
URGENT: Fix bug where ETH was being sent instead of wallet token

### DIFF
--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmationConnector.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmationConnector.js
@@ -57,6 +57,7 @@ const mapStateToProps = (state: State): Props => {
   } = state.ui.scenes.sendConfirmation
 
   const nativeAmount = parsedUri.nativeAmount || '0'
+  parsedUri.currencyCode = currencyCode
 
   let errorMsg = null
   if (error && parsedUri.nativeAmount && bns.gt(parsedUri.nativeAmount, '0')) {


### PR DESCRIPTION
Set the currencyCode in the parsedUri to the selected wallet currencyCode.