### PR TITLE
Fix TouchID popup occurring on login

### DIFF
--- a/src/modules/UI/scenes/Login/Login.ui.js
+++ b/src/modules/UI/scenes/Login/Login.ui.js
@@ -20,8 +20,10 @@ class Login extends Component {
 
   componentWillReceiveProps (nextProps) {
     // If we have logged out, destroy and recreate the login screen:
-    if (this.props.account && nextProps.account !== this.props.account)
-      this.setState({key: this.state.key + 1})
+    if (this.props.account && (nextProps.account !== this.props.account))
+      if (typeof nextProps.account.username === 'undefined') {
+        this.setState({key: this.state.key + 1})
+      }
   }
 
   render () {


### PR DESCRIPTION
Only remount the Login.ui scene when logging out. Check if nextProps.account.username is undefined as that will be the case upon logout but not upon login