### PR TITLE
Fix select first wallet on new account creation

### DIFF
--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -38,18 +38,13 @@ export const initializeAccount = (account: AbcAccount) => (dispatch: Dispatch, g
 
       dispatch(ACCOUNT_ACTIONS.addAccount(account))
       dispatch(SETTINGS_ACTIONS.setLoginStatus(true))
-      if (ACCOUNT_API.checkForExistingWallets(account)) {
-        const {
-          walletId,
-          currencyCode
-        } = ACCOUNT_API.getFirstActiveWalletInfo(account, currencyCodes)
-        dispatch(WALLET_ACTIONS.selectWallet(walletId, currencyCode))
-        dispatch(loadSettings())
-        return
+      if (!ACCOUNT_API.checkForExistingWallets(account)) {
+        // TODO: Allen - Turn on when Bitcoin is turned back on
+        // await dispatch(actions.createCurrencyWallet(strings.enUS['strings_first_bitcoin_44_wallet_name'], Constants.BITCOIN_44_WALLET, Constants.USD_FIAT, false)) //name.. walletType, fiat currency. TODO: get fiat to react to device.
+        await dispatch(actions.createCurrencyWallet(strings.enUS['string_first_ethereum_wallet_name'], Constants.ETHEREUM_WALLET, Constants.USD_FIAT, false))
       }
-      // TODO: Allen - Turn on when Bitcoin is turned back on
-      // await dispatch(actions.createCurrencyWallet(strings.enUS['strings_first_bitcoin_44_wallet_name'], Constants.BITCOIN_44_WALLET, Constants.USD_FIAT, false)) //name.. walletType, fiat currency. TODO: get fiat to react to device.
-      await dispatch(actions.createCurrencyWallet(strings.enUS['string_first_ethereum_wallet_name'], Constants.ETHEREUM_WALLET, Constants.USD_FIAT, false))
+      const {walletId, currencyCode} = ACCOUNT_API.getFirstActiveWalletInfo(account, currencyCodes)
+      dispatch(WALLET_ACTIONS.selectWallet(walletId, currencyCode))
       dispatch(loadSettings())
     })
 }


### PR DESCRIPTION
Previously,
1. On login, select wallet if account has wallet(s)
2. create wallet(s) if account lacks wallet(s)

Now,
1. On login, create wallet(s) if account lacks wallet(s)
2. select first wallet

This ensures that a wallet is selected when account is logged in