### PR TITLE
Fix reference to 'Bitcoin' and 'Priate Keys' for Scan address modal

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -312,7 +312,7 @@ const strings = {
   fragment_send_address: 'Address',
   fragment_send_photos: 'Photos',
   fragment_send_flash: 'Flash',
-  fragment_send_address_dialog_title: 'Send to Bitcoin Address or Import Private Key',
+  fragment_send_address_dialog_title: 'Send to Public Address',
   fragment_import_address_dialog_title: 'Sweep Funds From Private Key',
   fragment_send_other_wallet_header_title: 'Choose a wallet to transfer funds to:',
   fragment_send_create_wallet_to_transfer: 'Create a new wallet to transfer funds to',


### PR DESCRIPTION
The purpose of this task is to change syntax for public address input to be cryptocurrency-agnostic.

https://app.asana.com/0/361770107085503/459920947947995/f