### PR TITLE
Remove FlipInput underline on Android

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput.ui.js
@@ -97,6 +97,7 @@ export default class FlipInput extends Component<Props, State> {
         keyboardType='numeric'
         selectionColor='white'
         returnKeyType='done'
+        underlineColorAndroid={'transparent'}
       />
       <Text style={[top.currencyCode]}>
         {denominationInfo.displayDenomination.name}


### PR DESCRIPTION
The purpose of this task is to remove the teal underline in the FlipInput component for Android.

Asana Task: https://app.asana.com/0/361770107085503/459362679590645/f