### PR TITLE
Fix Android Text Cut Off on Currency Denomination Settings & Request (FlipInput)

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput.ui.js
@@ -5,7 +5,8 @@ import {
   Text,
   TextInput,
   TouchableWithoutFeedback,
-  View
+  View,
+  Platform
 } from 'react-native'
 import {styles, top, bottom} from './styles.js'
 import FAIcon from 'react-native-vector-icons/MaterialIcons'
@@ -88,7 +89,7 @@ export default class FlipInput extends Component<Props, State> {
       <Text style={[top.symbol]}>
         {denominationInfo.displayDenomination.symbol}
       </Text>
-      <TextInput style={[top.amount]}
+      <TextInput style={[top.amount, (Platform.OS === 'ios') ? {} : {paddingBottom: 2}]}
         placeholder={'0'}
         placeholderTextColor={'rgba(255, 255, 255, 0.60)'}
         value={this.topDisplayAmount()}

--- a/src/modules/UI/scenes/Settings/style.js
+++ b/src/modules/UI/scenes/Settings/style.js
@@ -106,9 +106,6 @@ export const styles = {
     justifyContent: 'space-between',
     height: 50
   },
-  headerTextWrap: {
-    height: 10
-  },
   headerText: {
     fontSize: 18,
     color: THEME.COLORS.WHITE,


### PR DESCRIPTION
The purpose of this task is to address two areas where text is cut off on Android, the Request scene's FlipInput (top TextInput) and the currency denomination settings.

Asana Task: https://app.asana.com/0/361770107085503/479270660285757/f