### PR TITLE
Modify Modal to not cast square shadow on Android.

### DIFF
--- a/src/modules/UI/components/Modal/Modal.ui.js
+++ b/src/modules/UI/components/Modal/Modal.ui.js
@@ -9,7 +9,6 @@ import Ionicon from 'react-native-vector-icons/Ionicons'
 import PropTypes from 'prop-types'
 import styles, {exitColor} from './style'
 import Modal from 'react-native-modal'
-import Gradient from '../Gradient/Gradient.ui'
 import T from '../FormattedText'
 import {border as b} from '../../../utils'
 
@@ -19,11 +18,9 @@ export default class StylizedModal extends Component {
     const exitIconName = (Platform.OS === 'ios' ? 'ios' : 'md') + '-close'
     return (
       <Modal style={[styles.topLevelModal, b('yellow')]} isVisible={this.props.visibilityBoolean}>
-        <Gradient style={[styles.modalHeaderIconWrapBottom]}>
-          <View style={styles.modalHeaderIconWrapTop}>
-            {this.props.featuredIcon}
-          </View>
-        </Gradient>
+        <View style={[styles.modalHeaderIconWrapBottom]}>
+          {this.props.featuredIcon}
+        </View>
         <View style={[styles.visibleModal]}>
           <View style={[styles.exitRow, b('green')]}>
             <TouchableOpacity

--- a/src/modules/UI/components/Modal/style.js
+++ b/src/modules/UI/components/Modal/style.js
@@ -58,6 +58,8 @@ export const styles = {
     position: 'relative',
     top: 27,
     borderRadius: 27,
+    borderWidth: 2,
+    borderColor: THEME.COLORS.PRIMARY,
     backgroundColor: THEME.COLORS.WHITE,
     height: 54,
     width: 54,
@@ -72,7 +74,8 @@ export const styles = {
     zIndex: 100,
     elevation: 100,
     height: 48,
-    width: 48
+    width: 48,
+    overflow: 'hidden'
   },
 
   // beginning of rename wallet modal

--- a/src/modules/UI/components/Modal/style.js
+++ b/src/modules/UI/components/Modal/style.js
@@ -59,7 +59,7 @@ export const styles = {
     top: 27,
     borderRadius: 27,
     borderWidth: 2,
-    borderColor: THEME.COLORS.PRIMARY,
+    borderColor: THEME.COLORS.SECONDARY,
     backgroundColor: THEME.COLORS.WHITE,
     height: 54,
     width: 54,


### PR DESCRIPTION
This removes the weird box present on some android phones. It is a direct result of layering two round items on top of each other. The fix was to kill the gradient, go with a 2 px border and have the icon center inside that. 