### PR TITLE
Create language localization framework

### DIFF
--- a/src/lib/LocaleStrings.js
+++ b/src/lib/LocaleStrings.js
@@ -1,5 +1,5 @@
 import defaultLang from '../locales/default'
-import enPH from '../locales/en_PH'
+import enPH from '../locales/es'
 const supportedLocales = {
   en_PH: enPH
 }

--- a/src/locales/en_PH.js
+++ b/src/locales/en_PH.js
@@ -1,5 +1,0 @@
-const strings = {
-  'Airbitz': 'Airbitz'
-}
-
-export default strings

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -1,0 +1,6 @@
+const strings = {
+  string_yes: 'Si',
+  fragment_wallets_header: 'Mis Carteras',
+}
+
+export default strings

--- a/src/locales/strings.js
+++ b/src/locales/strings.js
@@ -1,0 +1,58 @@
+// @flow
+import enUS from './en_US'
+import es from './es'
+
+const allLocales = { enUS, es }
+
+// Set default of US English
+const out = { strings: enUS }
+
+// Locale formats can be in the form 'en', 'en-US', 'en_US', or 'enUS'
+export function selectLocale (locale: string): boolean {
+  // Break up local into language and region
+  const normalizedLocale = locale.replace('-', '').replace('-', '').replace('_', '')
+  let choice = null
+
+  // Find exact match
+  if (allLocales[normalizedLocale] !== undefined) {
+    choice = allLocales[normalizedLocale]
+  } else {
+    // Match a match to a language with no dialect
+    const language = normalizedLocale.substr(0, 2)
+
+    choice = findLocale(language, false)
+
+    if (!choice) {
+      choice = findLocale(language, true)
+    }
+  }
+
+  if (choice) {
+    out.strings = Object.assign(enUS, choice)
+  }
+
+  return !!choice
+}
+
+// If region === false, then only match if locale has no region
+// Otherwise match the first matching language
+function findLocale (language: string, region: boolean) {
+  for (const locale in allLocales) {
+    if (allLocales.hasOwnProperty(locale)) {
+      const localeLang = locale.substr(0, 2)
+      const localeRegion = locale.substr(2)
+      if (localeLang === language) {
+        if (region === true) {
+          return allLocales[locale]
+        } else {
+          if (!localeRegion) {
+            return allLocales[locale]
+          }
+        }
+      }
+    }
+  }
+  return null
+}
+
+export default out

--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -7,7 +7,7 @@ import type {
   AbcContextOptions
 } from 'airbitz-core-types'
 import SplashScreen from 'react-native-smart-splash-screen'
-
+import { selectLocale } from '../locales/strings.js'
 import HockeyApp from 'react-native-hockeyapp'
 import React, {Component} from 'react'
 import {Keyboard, Platform, StatusBar, Image, AppState} from 'react-native'
@@ -193,6 +193,7 @@ export default class Main extends Component<Props, State> {
         this.props.addUsernames(usernames)
       })
       this.props.setLocaleInfo(localeInfo)
+      selectLocale(localeInfo.collatorIdentifier)
       SplashScreen.close({
         animationType: SplashScreen.animationType.fade,
         duration: 850,

--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -2,6 +2,7 @@
 
 import React, {Component} from 'react'
 import strings from '../../../../locales/default'
+import s from '../../../../locales/strings.js'
 import {bns} from 'biggystring'
 import {
   ActivityIndicator,
@@ -65,7 +66,7 @@ type State = {
 
 type TransactionListTx = any
 
-const SHOW_BALANCE_TEXT = strings.enUS['string_show_balance']
+const SHOW_BALANCE_TEXT = s.strings.string_show_balance
 const REQUEST_TEXT      = strings.enUS['fragment_request_subtitle']
 const SEND_TEXT         = strings.enUS['fragment_send_subtitle']
 const SENT_TEXT         = strings.enUS['fragment_transaction_list_sent_prefix']

--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -20,6 +20,7 @@ import SortableListView from 'react-native-sortable-listview'
 import FullWalletListRow from './components/WalletListRow/FullWalletListRowConnector'
 import SortableWalletListRow from './components/WalletListRow/SortableWalletListRow.ui.js'
 import strings from '../../../../locales/default'
+import s from '../../../../locales/strings.js'
 
 import StylizedModal from '../../components/Modal/Modal.ui'
 import * as UTILS from '../../../utils'
@@ -173,7 +174,7 @@ export default class WalletList extends Component<any, {
               <View style={styles.leftArea}>
                 <SimpleLineIcons name='wallet' style={[styles.walletIcon]} color='white' />
                 <T style={styles.walletsBoxHeaderText}>
-                  {strings.enUS['fragment_wallets_header']}
+                  {s.strings.fragment_wallets_header}
                 </T>
               </View>
             </View>


### PR DESCRIPTION
Localization files are named using ISO codes (ie. en_US, es, es_MX) and actual language is selected via selectLocale()
This needs migration of string syntax from

`import strings from '../../../../locales/default'`
`const SHOW_BALANCE_TEXT = strings.enUS['string_show_balance']`

to

`import s from '../../../../locales/strings.js'`
`const SHOW_BALANCE_TEXT = s.strings.string_show_balance`