### PR TITLE
Move Android Camera Permission to Scan Scene Render

### DIFF
--- a/src/modules/UI/scenes/Scan/Scan.ui.js
+++ b/src/modules/UI/scenes/Scan/Scan.ui.js
@@ -7,7 +7,8 @@ import {
   Alert,
   Text,
   View,
-  TouchableHighlight
+  TouchableHighlight,
+  Platform
 } from 'react-native'
 import T from '../../components/FormattedText'
 import Gradient from '../../components/Gradient/Gradient.ui'
@@ -70,8 +71,10 @@ export default class Scan extends Component<any, any> {
   }
   // check the status of a single permission
   componentDidMount () {
-    PERMISSIONS.request('camera')
-    .then(this.setCameraPermission)
+    if (Platform.OS === 'ios') {
+      PERMISSIONS.request('camera')
+      .then((resp) => this.setCameraPermission(resp))
+    }
   }
 
   renderDropUp = () => {
@@ -87,6 +90,10 @@ export default class Scan extends Component<any, any> {
   }
 
   render () {
+    if (Platform.OS === 'android' && !this.state.cameraPermission) {
+      PERMISSIONS.request('camera')
+      .then((resp) => this.setCameraPermission(resp))
+    }
     return (
       <View style={{flex: 1}}>
         <Gradient style={styles.gradient} />

--- a/src/modules/UI/scenes/Scan/Scan.ui.js
+++ b/src/modules/UI/scenes/Scan/Scan.ui.js
@@ -7,8 +7,7 @@ import {
   Alert,
   Text,
   View,
-  TouchableHighlight,
-  Platform
+  TouchableHighlight
 } from 'react-native'
 import T from '../../components/FormattedText'
 import Gradient from '../../components/Gradient/Gradient.ui'
@@ -69,13 +68,6 @@ export default class Scan extends Component<any, any> {
       cameraPermission: undefined
     }
   }
-  // check the status of a single permission
-  componentDidMount () {
-    if (Platform.OS === 'ios') {
-      PERMISSIONS.request('camera')
-      .then((resp) => this.setCameraPermission(resp))
-    }
-  }
 
   renderDropUp = () => {
     if (this.props.showToWalletModal) {
@@ -90,7 +82,7 @@ export default class Scan extends Component<any, any> {
   }
 
   render () {
-    if (Platform.OS === 'android' && !this.state.cameraPermission) {
+    if (!this.state.cameraPermission) {
       PERMISSIONS.request('camera')
       .then((resp) => this.setCameraPermission(resp))
     }


### PR DESCRIPTION
The purpose of this task is to get Android to properly ask for camera permissions (on first install / load and when accessing Scan scene).

Asana Task: https://app.asana.com/0/361770107085503/482710794616256/f