### PR TITLE
Fix onChangeText for Address modal (Scan scene)

### DIFF
--- a/src/modules/UI/scenes/Scan/components/AddressModal.js
+++ b/src/modules/UI/scenes/Scan/components/AddressModal.js
@@ -79,7 +79,9 @@ export default class AddressModal extends Component<Props,State> {
       copyMessage={copyMessage}
       onChangeText={this.onChangeText}
       onSubmit={this.onSubmit}
-      onPaste={this.onPasteFromClipboard} />
+      onPaste={this.onPasteFromClipboard}
+      uri={this.state.uri}
+      />
 
     const bottom = <AddressInputButtons
       onSubmit={this.onSubmit}


### PR DESCRIPTION
The purpose of this task is to fix the onChangeText functionality on the Address modal of the Scan scene, which seems to have been broken when we switched over to the newer (prettier) TextInput components.

Asana Task: https://app.asana.com/0/361770107085503/484205403928766/f