### PR TITLE
Only re-render the currently displayed scene

### DIFF
--- a/src/actions/RouterActions.js
+++ b/src/actions/RouterActions.js
@@ -1,0 +1,9 @@
+// @flow
+import {ActionConst} from 'react-native-router-flux'
+
+export const dispatchFocusRoute = (sceneName: string) => {
+  return {
+    type: ActionConst.FOCUS,
+    data: sceneName
+  }
+}

--- a/src/actions/indexActions.js
+++ b/src/actions/indexActions.js
@@ -1,6 +1,7 @@
 //@flow
 export * from './CryptoExchangeActions'
 export * from './EdgeLoginActions'
+export * from './RouterActions.js'
 export * from '../modules/UI/scenes/CreateWallet/action'
 export * from '../modules/UI/scenes/Scan/action'
 export * from '../modules/UI/components/ABAlert/action'

--- a/src/connectors/components/CryptoExchangeRateConnector.js
+++ b/src/connectors/components/CryptoExchangeRateConnector.js
@@ -12,6 +12,7 @@ export const mapStateToProps = (state: any, ownProps: any) => {
   const exchangeRateString = insufficient ? 'insufficient funds' : '1 '+fromCurrencyCode + ' = '+ exchangeRate +' '+ toCurrencyCode
 
   return {
+    sceneName: state.routes.scene.sceneName,
     style: ownProps.style,
     exchangeRate: exchangeRateString,
     insufficient

--- a/src/lib/routesReducer.js
+++ b/src/lib/routesReducer.js
@@ -1,20 +1,18 @@
 import {ActionConst} from 'react-native-router-flux'
 
 const initialState = {
-  scene: {},
-  stackDepth: 0
+  scene: {
+    sceneName: '',
+  }
 }
 
 export default function reducer (state = initialState, action = {}) {
   switch (action.type) {
   case ActionConst.FOCUS: {
-    let stackDepth
-      = parseInt(action.scene.key.replace(action.scene.sceneKey, '').replace('_', ''))
-
-    return {
-      ...state,
-      scene: action.scene,
-      stackDepth: stackDepth
+    return {...state,
+      scene: {
+        sceneName: action.data
+      }
     }
   }
   default:

--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -226,6 +226,15 @@ export default class Main extends Component<Props, State> {
     )
   }
 
+  onEnter = (sceneName: string) => () => {
+    // $FlowFixMe
+    global.currentScene = sceneName
+
+    if (sceneName === Constants.SCAN) {
+      this.props.dispatchEnableScan()
+    }
+  }
+
   renderWalletListNavBar = () => (
     <Header/>
   )
@@ -253,25 +262,27 @@ export default class Main extends Component<Props, State> {
                     <Scene hideNavBar>
                       {/*<Gradient>*/}
                       <Tabs key='edge' swipeEnabled={true} navTransparent={true} tabBarPosition={'bottom'} showLabel={true}>
-                        <Stack key={Constants.WALLET_LIST} navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} title='Wallets' icon={this.icon(Constants.WALLET_LIST)} activeTintColor={'transparent'} tabBarLabel='Wallets'>
-                          <Scene key='walletList_notused' component={WalletList} navTransparent={true} title='Wallets' renderLeftButton={() => <HelpButton/>} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} />
+                        <Stack key={Constants.WALLET_LIST} onEnter={this.onEnter(Constants.WALLET_LIST)} navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} title='Wallets' icon={this.icon(Constants.WALLET_LIST)} activeTintColor={'transparent'} tabBarLabel='Wallets'>
+                          <Scene key='walletList_notused' onEnter={this.onEnter(Constants.WALLET_LIST)} component={WalletList} navTransparent={true} title='Wallets' renderLeftButton={() => <HelpButton/>} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} />
                           <Scene key={Constants.CREATE_WALLET} back renderBackButton={this.renderWalletListBackButton} component={CreateWallet} tintColor={styles.backButtonColor} title='Create Wallet' navTransparent={true} animation={'fade'} duration={600} />
-                          <Scene key={Constants.TRANSACTION_LIST} back renderBackButton={this.renderWalletListBackButton} tintColor={styles.backButtonColor} navTransparent={true} icon={this.icon(Constants.TRANSACTION_LIST)} renderTitle={this.renderWalletListNavBar} component={TransactionListConnector} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} tabBarLabel='Transactions' title='Transactions' animation={'fade'} duration={600} />
+                          <Scene key={Constants.TRANSACTION_LIST} back renderBackButton={this.renderWalletListBackButton} onEnter={this.onEnter(Constants.TRANSACTION_LIST)} tintColor={styles.backButtonColor} navTransparent={true} icon={this.icon(Constants.TRANSACTION_LIST)} renderTitle={this.renderWalletListNavBar} component={TransactionListConnector} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} tabBarLabel='Transactions' title='Transactions' animation={'fade'} duration={600} />
                         </Stack>
-                        <Scene key={Constants.REQUEST} renderTitle={this.renderWalletListNavBar} navTransparent={true} icon={this.icon(Constants.REQUEST)} component={Request} tabBarLabel='Request' title='Request' renderLeftButton={() => <HelpButton/>} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} animation={'fade'} duration={600} />
+                        <Scene key={Constants.REQUEST} renderTitle={this.renderWalletListNavBar} navTransparent={true} icon={this.icon(Constants.REQUEST)} onEnter={this.onEnter(Constants.REQUEST)} component={Request} tabBarLabel='Request' title='Request' renderLeftButton={() => <HelpButton/>} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} animation={'fade'} duration={600} />
                         <Stack key={Constants.SCAN} title='Send' navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} icon={this.icon(Constants.SCAN)} tabBarLabel='Send' >
-                          <Scene key='scan_notused' renderTitle={this.renderWalletListNavBar} component={Scan} tintColor={styles.backButtonColor} navTransparent={true} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} onEnter={this.props.dispatchEnableScan} onExit={this.props.dispatchDisableScan} renderLeftButton={() => <HelpButton/>} tabBarLabel='Send' title='Send' animation={'fade'} duration={600} />
+                          <Scene key='scan_notused' renderTitle={this.renderWalletListNavBar} component={Scan} tintColor={styles.backButtonColor} navTransparent={true} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} onEnter={this.onEnter(Constants.SCAN)} onExit={this.props.dispatchDisableScan} renderLeftButton={() => <HelpButton/>} tabBarLabel='Send' title='Send' animation={'fade'} duration={600} />
                           <Scene key={Constants.EDGE_LOGIN}
                             renderTitle={'Edge Login'}
+                            onEnter={this.onEnter(Constants.EDGE_LOGIN)}
                             component={EdgeLoginSceneConnector}
                             renderLeftButton={() => <HelpButton/>}
                             animation={'fade'}
                             duration={200} />
                         </Stack>
-                        <Stack key={Constants.EXCHANGE} navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} icon={this.icon(Constants.EXCHANGE)} title='Exchange' animation={'fade'} duration={600} >
-                          <Scene key='exchange_notused' navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} icon={this.icon(Constants.EXCHANGE)} renderLeftButton={() => <ExchangeDropMenu/>} component={ExchangeConnector} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} tabBarLabel='Exchange' title='Exchange' animation={'fade'} duration={600} />
+                        <Stack key={Constants.EXCHANGE} navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} icon={this.icon(Constants.EXCHANGE)} onEnter={this.onEnter(Constants.EXCHANGE)} title='Exchange' animation={'fade'} duration={600} >
+                          <Scene key='exchange_notused' navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} icon={this.icon(Constants.EXCHANGE)} onEnter={this.onEnter(Constants.EXCHANGE)} renderLeftButton={() => <ExchangeDropMenu/>} component={ExchangeConnector} renderRightButton={() => <TouchableWithoutFeedback onPress={() => Actions.drawerOpen()}><Image source={MenuIcon}/></TouchableWithoutFeedback>} tabBarLabel='Exchange' title='Exchange' animation={'fade'} duration={600} />
                           <Scene
                             key={Constants.CHANGE_MINING_FEE_EXCHANGE}
+                            onEnter={this.onEnter(Constants.CHANGE_MINING_FEE_EXCHANGE)}
                             component={ChangeMiningFeeExchange}
                             onLeft={Actions.pop}
                             leftTitle='Back'
@@ -282,10 +293,11 @@ export default class Main extends Component<Props, State> {
                         />
                         </Stack>
                       </Tabs>
-                      <Stack key={Constants.SEND_CONFIRMATION} navTransparent={true} hideTabBar title='Send Confirmation' >
+                      <Stack key={Constants.SEND_CONFIRMATION} onEnter={this.onEnter(Constants.SEND_CONFIRMATION)} navTransparent={true} hideTabBar title='Send Confirmation' >
                         <Scene key='sendconfirmation_notused' hideTabBar component={SendConfirmation} back title='Send Confirmation' panHandlers={null} renderRightButton={() => <SendConfirmationOptions/>} animation={'fade'} duration={600} />
                         <Scene
                           key={Constants.CHANGE_MINING_FEE_SEND_CONFIRMATION}
+                          onEnter={this.onEnter(Constants.CHANGE_MINING_FEE_SEND_CONFIRMATION)}
                           component={ChangeMiningFeeSendConfirmation}
                           onLeft={Actions.pop}
                           navTransparent={false}
@@ -301,7 +313,7 @@ export default class Main extends Component<Props, State> {
                         <Scene key={Constants.ADD_TOKEN} component={AddToken} onLeft={Actions.pop} leftTitle='Back' back title='Add Token' />
                       </Stack>
                       <Stack key='settingsOverviewTab' title='Settings' navigationBarStyle={{backgroundColor: THEME.COLORS.PRIMARY}} hideDrawerButton={true} >
-                        <Scene key={Constants.SETTINGS_OVERVIEW} tintColor={styles.backButtonColor} navTransparent={true} component={SettingsOverview} title='Settings' onLeft={Actions.pop} leftTitle='Back' animation={'fade'} duration={600} />
+                        <Scene key={Constants.SETTINGS_OVERVIEW} tintColor={styles.backButtonColor} onEnter={this.onEnter(Constants.SETTINGS_OVERVIEW)} navTransparent={true} component={SettingsOverview} title='Settings' onLeft={Actions.pop} leftTitle='Back' animation={'fade'} duration={600} />
                         <Scene key={Constants.CHANGE_PASSWORD} tintColor={styles.backButtonColor} navTransparent={true} component={ChangePasswordConnector}   title='Change Password' animation={'fade'} duration={600} />
                         <Scene key={Constants.CHANGE_PIN}        component={ChangePinConnector}       navTransparent={true}  title='Change Pin' tintColor={styles.backButtonColor} animation={'fade'} duration={600} />
                         <Scene key={Constants.RECOVER_PASSWORD}  component={PasswordRecoveryConnector} title='Password Recovery' tintColor={styles.backButtonColor} animation={'fade'} duration={600} />

--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -120,6 +120,7 @@ type Props = {
   autoLogout: () => void,
   dispatchEnableScan: () => void,
   dispatchDisableScan: () => void,
+  dispatchFocusRoute: (sceneName: string) => void,
   contextCallbacks: AbcContextCallbacks
 }
 
@@ -227,9 +228,7 @@ export default class Main extends Component<Props, State> {
   }
 
   onEnter = (sceneName: string) => () => {
-    // $FlowFixMe
-    global.currentScene = sceneName
-
+    this.props.dispatchFocusRoute(sceneName)
     if (sceneName === Constants.SCAN) {
       this.props.dispatchEnableScan()
     }

--- a/src/modules/MainConnector.js
+++ b/src/modules/MainConnector.js
@@ -14,6 +14,7 @@ import {addCurrencyPlugin} from './UI/Settings/action.js'
 import {addUsernames} from './Core/Context/action'
 import {setLocaleInfo} from './UI/locale/action'
 import {enableScan, disableScan} from './UI/scenes/Scan/action'
+import {dispatchFocusRoute} from '../actions/indexActions.js'
 
 import makeContextCallbacks from './Core/Context/callbacks'
 
@@ -27,6 +28,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
   dispatchDisableScan: () => {
     return dispatch(disableScan())
+  },
+  dispatchFocusRoute: (sceneName: string) => {
+    return dispatch(dispatchFocusRoute(sceneName))
   },
   addExchangeTimer: () => dispatch(addExchangeTimer()),
   addCurrencyPlugin: (plugin) => dispatch(addCurrencyPlugin(plugin)),

--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
@@ -53,6 +53,12 @@ type State = {
   whichWallet: string
 }
 export default class CryptoExchangeSceneComponent extends Component<Props, State> {
+  shouldComponentUpdate (nextProps, nextState) {
+    if (global.currentScene === Constants.EXCHANGE) {
+      return true
+    }
+    return false
+  }
 
   componentWillMount () {
     if (this.props.wallets.length > 1) {

--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
@@ -18,7 +18,8 @@ import {GuiWallet} from '../../../../types'
 // $FlowFixMe
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 
-type Props ={
+type Props = {
+  sceneName: string,
   exchangeRate: number,
   wallets: Array<GuiWallet>,
   intialWalletOne: GuiWallet,
@@ -53,11 +54,8 @@ type State = {
   whichWallet: string
 }
 export default class CryptoExchangeSceneComponent extends Component<Props, State> {
-  shouldComponentUpdate (nextProps, nextState) {
-    if (global.currentScene === Constants.EXCHANGE) {
-      return true
-    }
-    return false
+  shouldComponentUpdate (nextProps: Props) {
+    return (nextProps.sceneName === Constants.EXCHANGE)
   }
 
   componentWillMount () {

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -33,12 +33,10 @@ export default class Request extends Component {
     }
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    if (global.currentScene === Constants.REQUEST) {
-      return true
-    }
-    return false
+  shouldComponentUpdate (nextProps) {
+    return (nextProps.sceneName === Constants.REQUEST)
   }
+
   componentWillReceiveProps (nextProps) {
     if (nextProps.abcWallet.id !== this.props.abcWallet.id) {
       const {abcWallet, currencyCode} = nextProps

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -33,6 +33,12 @@ export default class Request extends Component {
     }
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    if (global.currentScene === Constants.REQUEST) {
+      return true
+    }
+    return false
+  }
   componentWillReceiveProps (nextProps) {
     if (nextProps.abcWallet.id !== this.props.abcWallet.id) {
       const {abcWallet, currencyCode} = nextProps

--- a/src/modules/UI/scenes/Request/RequestConnector.js
+++ b/src/modules/UI/scenes/Request/RequestConnector.js
@@ -20,6 +20,7 @@ const mapStateToProps = (state: State) => {
   const currencyCode: string = UI_SELECTORS.getSelectedCurrencyCode(state)
   if (!guiWallet || !currencyCode) {
     return {
+      sceneName: state.routes.scene.sceneName,
       loading: true,
       request: {},
       abcWallet: {},

--- a/src/modules/UI/scenes/Scan/Scan.ui.js
+++ b/src/modules/UI/scenes/Scan/Scan.ui.js
@@ -69,6 +69,12 @@ export default class Scan extends Component<any, any> {
     }
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    if (global.currentScene === Constants.SCAN) {
+      return true
+    }
+    return false
+  }
   renderDropUp = () => {
     if (this.props.showToWalletModal) {
       return (

--- a/src/modules/UI/scenes/Scan/Scan.ui.js
+++ b/src/modules/UI/scenes/Scan/Scan.ui.js
@@ -69,12 +69,10 @@ export default class Scan extends Component<any, any> {
     }
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    if (global.currentScene === Constants.SCAN) {
-      return true
-    }
-    return false
+  shouldComponentUpdate (nextProps: Props) {
+    return (nextProps.sceneName === Constants.SCAN)
   }
+
   renderDropUp = () => {
     if (this.props.showToWalletModal) {
       return (

--- a/src/modules/UI/scenes/Scan/ScanConnector.js
+++ b/src/modules/UI/scenes/Scan/ScanConnector.js
@@ -20,13 +20,10 @@ import {toggleWalletListModal} from '../WalletTransferList/action'
 const mapStateToProps = (state: any) => {
   const walletId: string = UI_SELECTORS.getSelectedWalletId(state)
   const abcWallet: AbcCurrencyWallet = CORE_SELECTORS.getWallet(state, walletId)
-  const sceneName:? string = state.routes.scene.children
-    ? state.routes.scene.children[state.routes.scene.index].name
-    : null
 
   return {
     abcWallet,
-    sceneName,
+    sceneName: state.routes.scene.sceneName,
     torchEnabled: state.ui.scenes.scan.torchEnabled,
     scanEnabled: state.ui.scenes.scan.scanEnabled,
     walletListModalVisible: state.ui.scenes.walletTransferList.walletListModalVisible,

--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -92,6 +92,12 @@ export default class TransactionList extends Component<Props, State> {
     width: undefined
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    if (global.currentScene === Constants.TRANSACTION_LIST) {
+      return true
+    }
+    return false
+  }
   componentDidMount () {
     if (this.props.loading) return
 

--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -38,6 +38,7 @@ from '../../../UI/components/WalletListModal/WalletListModalConnector'
 import * as Constants from '../../../../constants/indexConstants'
 
 type Props = {
+  sceneName: string,
   getTransactions: (walletId: string, currencyCode: string) => void,
   updateExchangeRates: () => void,
   setContactList: (contacts: Array<any>) => void,
@@ -92,12 +93,10 @@ export default class TransactionList extends Component<Props, State> {
     width: undefined
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    if (global.currentScene === Constants.TRANSACTION_LIST) {
-      return true
-    }
-    return false
+  shouldComponentUpdate (nextProps: Props) {
+    return (nextProps.sceneName === Constants.TRANSACTION_LIST)
   }
+
   componentDidMount () {
     if (this.props.loading) return
 

--- a/src/modules/UI/scenes/TransactionList/TransactionListConnector.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionListConnector.js
@@ -38,6 +38,7 @@ const mapStateToProps = (state) => {
   const balanceInFiat = currencyConverter.convertCurrency(currencyCode, isoFiatCurrencyCode, balanceInCryptoDisplay)
   const displayDenomination = SETTINGS_SELECTORS.getDisplayDenomination(state, currencyCode)
   return {
+    sceneName: state.routes.scene.sceneName,
     displayDenomination,
     updatingBalance: false,
     transactions,

--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -32,7 +32,7 @@ import RenameWalletButtons from './components/RenameWalletButtonsConnector'
 import DeleteIcon from './components/DeleteIcon.ui'
 import RenameIcon from './components/RenameIcon.ui'
 import platform from '../../../../theme/variables/platform.js'
-
+import * as Constants from '../../../../constants/indexConstants.js'
 
 const options = [
   {
@@ -78,12 +78,10 @@ export default class WalletList extends Component<any, {
     }
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    if (global.currentScene === Constants.WALLET_LIST) {
-      return true
-    }
-    return false
+  shouldComponentUpdate (nextProps: any) {
+    return (nextProps.sceneName === Constants.WALLET_LIST)
   }
+
   componentDidMount () {
     Permissions.request('contacts').then((response) => {
       if (response === 'authorized') {

--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -78,6 +78,12 @@ export default class WalletList extends Component<any, {
     }
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    if (global.currentScene === Constants.WALLET_LIST) {
+      return true
+    }
+    return false
+  }
   componentDidMount () {
     Permissions.request('contacts').then((response) => {
       if (response === 'authorized') {

--- a/src/modules/UI/scenes/WalletList/WalletListConnector.js
+++ b/src/modules/UI/scenes/WalletList/WalletListConnector.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state: any): {} => {
 
   return {
     settings,
+    sceneName: state.routes.scene.sceneName,
     coreWallets: state.core.wallets.byId,
     wallets: state.ui.wallets.byId,
     activeWalletIds: UI_SELECTORS.getActiveWalletIds(state),


### PR DESCRIPTION
Track the current scene using a `global.currencyScene` and the `onEnter` parameter of the router.
Return false in shouldComponentUpdate if the scene is not the current scene.

Brings Core callback updates to GUI down from 300ms+ to about 70ms