### PR TITLE
Fix: No content in help modal 

### DIFF
--- a/src/modules/UI/components/HelpModal/HelpModal.ui.js
+++ b/src/modules/UI/components/HelpModal/HelpModal.ui.js
@@ -36,6 +36,11 @@ export default class HelpModal extends Component {
               this.props.closeModal()
             }
           }} />}
+        modalBodyStyle={styles.modalBodyStyle}
+        modalVisibleStyle={styles.modalVisibleStyle}
+        modalBoxStyle={styles.modalBoxStyle}
+        modalContentStyle={styles.modalContentStyle}
+        modalMiddleStyle={styles.modalMiddleWebView}
         modalBottom={<View style={[styles.modalBottomContainer]}>
                         <Text style={styles.modalBottomText}>{strings.enUS['help_version']} {versionNumber}</Text>
                         <Text style={styles.modalBottomText}>{strings.enUS['help_build']} {buildNumber}</Text>

--- a/src/modules/UI/components/HelpModal/style.js
+++ b/src/modules/UI/components/HelpModal/style.js
@@ -9,7 +9,6 @@ export default StyleSheet.create({
   webView: {
     justifyContent: 'center',
     alignItems:'center',
-    height: 240,
     flex: 1
   },
   modalBottomContainer: {
@@ -23,7 +22,19 @@ export default StyleSheet.create({
     padding: 4
   },
   modalMiddleWebView: {
-
+    flex: 1,
+  },
+  modalVisibleStyle: {
+    flex: 1,
+  },
+  modalBoxStyle: {
+    flex: 1,
+  },
+  modalContentStyle: {
+    flex: 1,
+  },
+  modalBodyStyle: {
+    flex: 1,
   },
   modalFeaturedIcon: {
     top: 12,

--- a/src/modules/UI/components/Modal/Modal.ui.js
+++ b/src/modules/UI/components/Modal/Modal.ui.js
@@ -20,6 +20,10 @@ type Props = {
   headerSubtext?: string,
   visibilityBoolean: boolean,
   featuredIcon: Node,
+  modalVisibleStyle?: {},
+  modalBoxStyle?: {},
+  modalContentStyle?: {},
+  modalBodyStyle?: {},
   modalMiddle: Node,
   modalMiddleStyle?: {},
   modalBottom: Node,
@@ -39,7 +43,7 @@ export default class StylizedModal extends Component<Props, State> {
           {this.props.featuredIcon}
         </View>
 
-        <View style={[styles.visibleModal]}>
+        <View style={[styles.visibleModal, this.props.modalVisibleStyle]}>
 
           <View style={[styles.exitRow]}>
             <TouchableOpacity
@@ -49,9 +53,9 @@ export default class StylizedModal extends Component<Props, State> {
             </TouchableOpacity>
           </View>
 
-          <View style={[styles.modalBox]}>
-            <View style={[styles.modalContent]}>
-              <View style={[styles.modalBody]}>
+          <View style={[styles.modalBox, this.props.modalBoxStyle]}>
+            <View style={[styles.modalContent, this.props.modalContentStyle]}>
+              <View style={[styles.modalBody, this.props.modalBodyStyle]}>
 
                 <View style={[styles.modalTopTextWrap]}>
                   <T style={[styles.modalTopText, this.props.headerTextStyle]}>


### PR DESCRIPTION
iOS. Tap “Help” in upper left of most screens. The modal should show help content but is blank. 