### PR TITLE
Clean start for exchange scene

### DIFF
--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -13,6 +13,7 @@ import {bns} from 'biggystring'
 import type {FlipInputFieldInfo} from '../modules/UI/components/FlipInput/FlipInput.ui'
 import strings from '../locales/default'
 import {checkShiftTokenAvailability} from '../modules/UI/scenes/CryptoExchange/CryptoExchangeSupportedTokens'
+
 const DIVIDE_PRECISION = 18
 
 export type SetNativeAmountInfo = {
@@ -93,27 +94,28 @@ export const setNativeAmount = (info: SetNativeAmountInfo) => (dispatch: any, ge
   if (whichWallet === Constants.FROM) {
     const fromDisplayAmount = bns.div(primaryNativeAmount, fromPrimaryInfo.displayDenomination.multiplier, DIVIDE_PRECISION)
     const fromExchangeAmount = bns.div(primaryNativeAmount, fromPrimaryInfo.exchangeDenomination.multiplier, DIVIDE_PRECISION)
-
-    const toExchangeAmount = bns.mul(fromExchangeAmount, state.cryptoExchange.exchangeRate.toFixed(3))
-
-    const toNativeAmount = bns.mul(toExchangeAmount, toPrimaryInfo.exchangeDenomination.multiplier)
-    const toDisplayAmountTemp = bns.div(toNativeAmount, toPrimaryInfo.displayDenomination.multiplier, DIVIDE_PRECISION)
-    const toDisplayAmount = bns.toFixed(toDisplayAmountTemp, 0, 8)
-
     dispatch(setCryptoNativeDisplayAmount(Constants.SET_CRYPTO_FROM_NATIVE_AMOUNT, {native: primaryNativeAmount, display: fromDisplayAmount}))
-    dispatch(setCryptoNativeDisplayAmount(Constants.SET_CRYPTO_TO_NATIVE_AMOUNT, {native: toNativeAmount, display: toDisplayAmount}))
+
+    if (toWallet) {
+      const toExchangeAmount = bns.mul(fromExchangeAmount, state.cryptoExchange.exchangeRate.toFixed(3))
+      const toNativeAmount = bns.mul(toExchangeAmount, toPrimaryInfo.exchangeDenomination.multiplier)
+      const toDisplayAmountTemp = bns.div(toNativeAmount, toPrimaryInfo.displayDenomination.multiplier, DIVIDE_PRECISION)
+      const toDisplayAmount = bns.toFixed(toDisplayAmountTemp, 0, 8)
+      dispatch(setCryptoNativeDisplayAmount(Constants.SET_CRYPTO_TO_NATIVE_AMOUNT, {native: toNativeAmount, display: toDisplayAmount}))
+    }
+
   } else {
     const toDisplayAmount = bns.div(primaryNativeAmount, toPrimaryInfo.displayDenomination.multiplier, DIVIDE_PRECISION)
     const toExchangeAmount = bns.div(primaryNativeAmount, toPrimaryInfo.exchangeDenomination.multiplier, DIVIDE_PRECISION)
-
-    const fromExchangeAmount = bns.div(toExchangeAmount, state.cryptoExchange.exchangeRate.toFixed(3), DIVIDE_PRECISION)
-
-    const fromNativeAmount = bns.mul(fromExchangeAmount, fromPrimaryInfo.exchangeDenomination.multiplier)
-    const fromDisplayAmountTemp = bns.div(fromNativeAmount, fromPrimaryInfo.displayDenomination.multiplier, DIVIDE_PRECISION)
-    const fromDisplayAmount = bns.toFixed(fromDisplayAmountTemp, 0, 8)
-
     dispatch(setCryptoNativeDisplayAmount(Constants.SET_CRYPTO_TO_NATIVE_AMOUNT, {native: primaryNativeAmount, display: toDisplayAmount}))
-    dispatch(setCryptoNativeDisplayAmount(Constants.SET_CRYPTO_FROM_NATIVE_AMOUNT, {native: fromNativeAmount, display: fromDisplayAmount}))
+
+    if (fromWallet) {
+      const fromExchangeAmount = bns.div(toExchangeAmount, state.cryptoExchange.exchangeRate.toFixed(3), DIVIDE_PRECISION)
+      const fromNativeAmount = bns.mul(fromExchangeAmount, fromPrimaryInfo.exchangeDenomination.multiplier)
+      const fromDisplayAmountTemp = bns.div(fromNativeAmount, fromPrimaryInfo.displayDenomination.multiplier, DIVIDE_PRECISION)
+      const fromDisplayAmount = bns.toFixed(fromDisplayAmountTemp, 0, 8)
+      dispatch(setCryptoNativeDisplayAmount(Constants.SET_CRYPTO_FROM_NATIVE_AMOUNT, {native: fromNativeAmount, display: fromDisplayAmount}))
+    }
   }
 
   // make spend
@@ -129,7 +131,7 @@ export const setNativeAmount = (info: SetNativeAmountInfo) => (dispatch: any, ge
         dispatch(actions.dispatchAction(Constants.RECEIVED_DUST_ERROR))
         return
       }
-      console.warn('creating shift transaction failed' , e)
+      dispatch(actions.dispatchActionString(Constants.GENERIC_SHAPE_SHIFT_ERROR, e.message))
     })
   }
 }
@@ -183,7 +185,6 @@ const getShiftTransaction = (fromWallet: GuiWallet, toWallet: GuiWallet) => asyn
   }
   const srcCurrencyCode = spendInfo.currencyCode
   const destCurrencyCode = spendInfo.spendTargets[0].currencyCode
-  console.log('stop for breakpoint')
   if (srcCurrencyCode !== destCurrencyCode) {
     let abcTransaction = await srcWallet.makeSpend(spendInfo)
     const primaryInfo = state.cryptoExchange.fromWalletPrimaryInfo

--- a/src/connectors/components/CryptoExchangeRateConnector.js
+++ b/src/connectors/components/CryptoExchangeRateConnector.js
@@ -3,14 +3,16 @@ import {connect} from 'react-redux'
 import LinkedComponent
   from '../../modules/UI/components/CryptoExchangeRate/CryptoExchangeRate'
 // import * as actions from '../../actions/indexActions'
-
+import strings from '../../locales/default'
 export const mapStateToProps = (state: any, ownProps: any) => {
   const fromCurrencyCode = state.cryptoExchange.fromCurrencyCode
   const exchangeRate = state.cryptoExchange.exchangeRate
   const toCurrencyCode = state.cryptoExchange.toCurrencyCode
   const insufficient = state.cryptoExchange.insufficientError
-  const exchangeRateString = insufficient ? 'insufficient funds' : '1 '+fromCurrencyCode + ' = '+ exchangeRate +' '+ toCurrencyCode
-
+  let exchangeRateString = ''
+  if (fromCurrencyCode && toCurrencyCode) {
+    exchangeRateString = insufficient ? strings.enUS['fragment_insufficient_funds'] : '1 '+fromCurrencyCode + ' = '+ exchangeRate +' '+ toCurrencyCode
+  }
   return {
     style: ownProps.style,
     exchangeRate: exchangeRateString,

--- a/src/connectors/components/CryptoExchangeRateConnector.js
+++ b/src/connectors/components/CryptoExchangeRateConnector.js
@@ -9,9 +9,16 @@ export const mapStateToProps = (state: any, ownProps: any) => {
   const exchangeRate = state.cryptoExchange.exchangeRate
   const toCurrencyCode = state.cryptoExchange.toCurrencyCode
   const insufficient = state.cryptoExchange.insufficientError
+  const genericError = state.cryptoExchange.genericShapeShiftError
   let exchangeRateString = ''
   if (fromCurrencyCode && toCurrencyCode) {
-    exchangeRateString = insufficient ? strings.enUS['fragment_insufficient_funds'] : '1 '+fromCurrencyCode + ' = '+ exchangeRate +' '+ toCurrencyCode
+    exchangeRateString = '1 '+fromCurrencyCode + ' = '+ exchangeRate +' '+ toCurrencyCode
+    if (insufficient) {
+      exchangeRateString = strings.enUS['fragment_insufficient_funds']
+    }
+    if (genericError) {
+      exchangeRateString = genericError
+    }
   }
   return {
     style: ownProps.style,

--- a/src/constants/ActionConstants.js
+++ b/src/constants/ActionConstants.js
@@ -16,6 +16,7 @@ export const SET_CRYPTO_FROM_NATIVE_AMOUNT = 'setCryptoFromNativeAmount'
 export const SET_CRYPTO_TO_NATIVE_AMOUNT = 'setCryptoToNativeAmount'
 export const RECEIVED_TRANSACTION_ERROR = 'receivedTRansactionError'
 export const RECEIVED_INSUFFICIENT_FUNDS_ERROR = 'receivedInsufficentFundsError'
+export const GENERIC_SHAPE_SHIFT_ERROR = 'genericShapeShiftError'
 export const RECEIVED_DUST_ERROR = 'receivedInsufficentFundsError'
 export const CHANGE_EXCHANGE_FEE = 'CHANGE_EXCHANGE_FEE'
 // Alert

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -876,7 +876,10 @@ const strings = {
   exchange_failed: 'Exchange Failed',
   exchanges_may_take_minutes: 'Exchanges may take several minutes to process. Please check your destination wallet after a few minutes',
   could_not_select: 'Could Not Select Wallet',
-  token_not_supported: 'Token is not supported by exchange'
+  token_not_supported: 'Token is not supported by exchange',
+  select_src_wallet: 'Select Source Wallet',
+  select_dest_wallet: 'Select Dest Wallet',
+  fragment_insufficient_funds: 'insufficient funds'
 }
 
 export default strings

--- a/src/modules/UI/components/CryptoExchangeRate/CryptoExchangeRate.js
+++ b/src/modules/UI/components/CryptoExchangeRate/CryptoExchangeRate.js
@@ -14,7 +14,7 @@ export default class CryptoExchageRate extends Component<Props> {
       textError
     } = this.props.style
     return (
-      <View style={[container, this.props.insufficient && containerError]}>
+      <View style={[container, (this.props.insufficient || this.props.genericError) && containerError]}>
           <Text style={[text,this.props.insufficient && textError ]}>{this.props.exchangeRate}</Text>
       </View>
     )

--- a/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
+++ b/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
@@ -8,6 +8,7 @@ import {GuiWallet} from '../../../../types'
 import type {AbcCurrencyWallet} from 'airbitz-core-types'
 import * as UTILS from '../../../utils'
 import type {SetNativeAmountInfo} from '../../../../actions/CryptoExchangeActions'
+import strings from '../../../../locales/default'
 
 type Props = {
   style: any,
@@ -67,9 +68,6 @@ export default class CryptoExchangeFlipInputWrapperComponent extends Component<P
 
   render () {
     const style = this.props.style
-    if (!this.props.uiWallet) {
-      return <View style={style.container} />
-    }
     const {
       primaryInfo,
       secondaryInfo,
@@ -77,6 +75,21 @@ export default class CryptoExchangeFlipInputWrapperComponent extends Component<P
       nativeAmount,
       currencyCode
     } = this.props
+
+    if (!this.props.uiWallet) {
+      const buttonText = this.props.whichWallet === Constants.TO ? strings.enUS['select_dest_wallet'] : strings.enUS['select_src_wallet']
+      return <View style={[style.containerNoFee, this.props.fee && style.container]}>
+        <View style={style.topRow}>
+              <TextAndIconButton
+                style={style.walletSelector}
+                onPress={this.launchSelector}
+                icon={Constants.KEYBOARD_ARROW_DOWN}
+                title={buttonText}
+              />
+            </View>
+        </View>
+    }
+
     return (
       <View style={[style.containerNoFee, this.props.fee && style.container]}>
         <View style={style.topRow}>

--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
@@ -55,28 +55,12 @@ type State = {
 export default class CryptoExchangeSceneComponent extends Component<Props, State> {
 
   componentWillMount () {
-    if (this.props.wallets.length > 1) {
-      this.props.selectFromWallet(this.props.intialWalletOne)
-      this.props.selectToWallet(this.props.intialWalletTwo)
-    } else if (this.props.wallets.length > 0) {
-      this.props.selectFromWallet(this.props.intialWalletOne)
-    }
     this.setState({
       whichWallet: Constants.FROM
     })
 
   }
-  componentWillReceiveProps (nextProps: Props) {
-    if (!nextProps.fromWallet && nextProps.intialWalletOne) {
-      this.props.selectFromWallet(nextProps.intialWalletOne)
-      if (nextProps.wallets.length === 1) {
-        this.props.selectToWallet(nextProps.intialWalletOne)
-      }
-    }
-    if (!nextProps.toWallet && nextProps.intialWalletTwo) {
-      this.props.selectToWallet(nextProps.intialWalletTwo)
-    }
-  }
+
   renderButton = () => {
     if (this.props.showNextButton) {
       return <PrimaryButton text={strings.enUS['string_next']} onPressFunction={this.props.openConfirmation} />

--- a/src/reducers/CryptoExchangeReducer.js
+++ b/src/reducers/CryptoExchangeReducer.js
@@ -30,6 +30,7 @@ const initialState = {
   walletListModalVisible: false,
   confirmTransactionModalVisible: false,
   shiftTransactionError: null,
+  genericShapeShiftError: null,
   changeWallet: Constants.NONE,
   transaction: null
 }
@@ -73,17 +74,14 @@ function cryptoExchangerReducer (state = initialState, action) {
   case Constants.UPDATE_CRYPTO_REVERSE_EXCHANGE_RATE:
     return {...state, reverseExchange: action.data}
   case Constants.UPDATE_SHIFT_TRANSACTION:
-    return {...state, transaction: action.data.abcTransaction, fee: action.data.networkFee && state.fromCurrencyCode ? strings.enUS['string_fee'] + ' ' + action.data.networkFee + ' ' + state.fromCurrencyCode : ' ', insufficientError: false}
+    return {...state, transaction: action.data.abcTransaction,
+      fee: action.data.networkFee && state.fromCurrencyCode ? strings.enUS['string_fee'] + ' ' + action.data.networkFee + ' ' + state.fromCurrencyCode : ' ',
+      insufficientError: false,
+      genericShapeShiftError: null}
   case Constants.INVALIDATE_SHIFT_TRANSACTION:
-    return {...state, transaction: null, insufficientError: false}
+    return {...state, transaction: null, insufficientError: false, genericShapeShiftError: null}
   case Constants.SHIFT_COMPLETE:
-    return {...state,
-      transaction: null,
-      confirmTransactionModalVisible: false,
-      fromNativeAmount: '0',
-      toNativeAmount:'0',
-      fromDisplayAmount: '0',
-      toDisplayAmount: '0'}
+    return initialState
   case Constants.SHIFT_ERROR:
     return {...state, confirmTransactionModalVisible: false, shiftTransactionError: action.data}
   case Constants.CLOSE_CRYPTO_EXC_CONF_MODAL:
@@ -96,6 +94,8 @@ function cryptoExchangerReducer (state = initialState, action) {
     return {...state, fromNativeAmount: action.data.native, fromDisplayAmount:action.data.display}
   case Constants.RECEIVED_INSUFFICIENT_FUNDS_ERROR :
     return {...state, transaction: null, insufficientError: true}
+  case Constants.GENERIC_SHAPE_SHIFT_ERROR :
+    return {...state, transaction: null, genericShapeShiftError: action.data}
   case Constants.CHANGE_EXCHANGE_FEE :
     return {...state,  feeSetting: action.feeSetting}
   default:


### PR DESCRIPTION
Starts Shape Shift screen with the ability for users to select what wallets they want instead of automatically doing it. 
Fixed errors caused by the above change
Added additional error handling when tokens are not available. 
Reset scene when shift is successful. 