### PR TITLE
Remove magic error strings

### DIFF
--- a/src/actions/CryptoExchangeActions.js
+++ b/src/actions/CryptoExchangeActions.js
@@ -1,4 +1,5 @@
 // @flow
+import {error} from 'airbitz-core-react-native'
 import {Alert} from 'react-native'
 import type {GuiWallet,GuiDenomination, GuiCurrencyInfo} from '../types'
 import * as Constants from '../constants/indexConstants'
@@ -123,11 +124,11 @@ export const setNativeAmount = (info: SetNativeAmountInfo) => (dispatch: any, ge
     dispatch(getShiftTransaction(fromWallet, toWallet)).catch((e) => {
       console.log(' ERROR getting shidt transaction. ')
       console.log(e)
-      if (e.name === Constants.INSUFFICIENT_FUNDS || e.message === Constants.INSUFFICIENT_FUNDS) {
+      if (e.name === error.InsufficientFundsError.name) {
         dispatch(actions.dispatchAction(Constants.RECEIVED_INSUFFICIENT_FUNDS_ERROR))
         return
       }
-      if (e.message === Constants.DUST) {
+      if (e.name === error.DustSpendError.name) {
         dispatch(actions.dispatchAction(Constants.RECEIVED_DUST_ERROR))
         return
       }

--- a/src/constants/ErrorConstants.js
+++ b/src/constants/ErrorConstants.js
@@ -1,2 +1,0 @@
-export const INSUFFICIENT_FUNDS = 'InsufficientFundsError'
-export const DUST = 'Output is dust.'

--- a/src/constants/indexConstants.js
+++ b/src/constants/indexConstants.js
@@ -5,7 +5,6 @@ export * from '../modules/UI/components/WalletListModal/action'
 export * from './DropDownValueConstants'
 export * from './WalletAndCurrencyConstants'
 export * from './FeeConstants'
-export * from './ErrorConstants'
 
 export const LEFT_TO_RIGHT = 'leftToRight'
 export const RIGHT_TO_LEFT = 'rightToLeft'


### PR DESCRIPTION
The core exports these error types symbolically, so use that instead.