### PR TITLE
Fix multitude of crashes in GUI after account creation

### DIFF
--- a/src/modules/Core/Account/reducer.js
+++ b/src/modules/Core/Account/reducer.js
@@ -1,12 +1,12 @@
 import * as ACTION from './action.js'
 
 export const accountReducer = (state = {}, action) => {
-  const {type, data = {} } = action
-  const {account} = data
-
-  switch (type) {
+  switch (action.type) {
   case ACTION.ADD_ACCOUNT:
-    return account
+    if (action.data) {
+      return action.data.account
+    }
+    return state
   default:
     return state
   }

--- a/src/modules/Core/Account/reducer.js
+++ b/src/modules/Core/Account/reducer.js
@@ -1,6 +1,14 @@
-import * as ACTION from './action.js'
+// @flow
 
-export const accountReducer = (state = {}, action) => {
+import * as ACTION from './action.js'
+import type {Action} from '../../ReduxTypes.js'
+import type {AbcAccount} from 'airbitz-core-types'
+
+type AccountReducerState = AbcAccount | {} | void
+
+export const initialState: AccountReducerState = {}
+
+const accountReducer = (state = initialState, action) => {
   switch (action.type) {
   case ACTION.ADD_ACCOUNT:
     if (action.data) {
@@ -12,7 +20,7 @@ export const accountReducer = (state = {}, action) => {
   }
 }
 
-export const account = (state, action) => {
+export const account = (state: AccountReducerState, action: Action) => {
   if (action.type === 'LOGOUT') {
     state = undefined
   }

--- a/src/modules/UI/Request/reducer.js
+++ b/src/modules/UI/Request/reducer.js
@@ -16,15 +16,19 @@ const initialState = {
 }
 
 export const request = (state = initialState, action) => {
-  const {type, data = {} } = action
-  const {receiveAddress, amountSatoshi, amountFiat} = data
-  switch (type) {
+  let receiveAddress
+  let amountSatoshi
+  let amountFiat
+
+  switch (action.type) {
   case ACTION.UPDATE_RECEIVE_ADDRESS_SUCCESS:
+    receiveAddress = action.data.receiveAddress
     return {
       ...state,
       receiveAddress
     }
   case 'UPDATE_AMOUNT_REQUESTED_IN_CRYPTO':
+    amountSatoshi = action.data.amountSatoshi
     return {
       ...state,
       receiveAddress: {
@@ -33,6 +37,7 @@ export const request = (state = initialState, action) => {
       }
     }
   case 'UPDATE_AMOUNT_REQUESTED_IN_FIAT':
+    amountFiat = action.data.amountFiat
     return {
       ...state,
       receiveAddress: {

--- a/src/modules/UI/Request/reducer.js
+++ b/src/modules/UI/Request/reducer.js
@@ -1,6 +1,24 @@
-import * as ACTION from './action'
+// @flow
 
-const initialState = {
+import * as ACTION from './action'
+import type {Action} from '../../ReduxTypes.js'
+
+export type RequestState = {
+  receiveAddress: {
+    publicAddress: string,
+    amountSatoshi: number,
+    metadata: {
+      payeeName: string,
+      category: string,
+      notes: string,
+      amountFiat: number,
+      bizId: null,
+      miscJson: string
+    }
+  }
+}
+
+const initialState: RequestState = {
   receiveAddress: {
     publicAddress: '',
     amountSatoshi: 0,
@@ -15,10 +33,14 @@ const initialState = {
   }
 }
 
-export const request = (state = initialState, action) => {
+export const request = (state: RequestState = initialState, action: Action): RequestState => {
   let receiveAddress
   let amountSatoshi
   let amountFiat
+
+  if (!action.data) {
+    return state
+  }
 
   switch (action.type) {
   case ACTION.UPDATE_RECEIVE_ADDRESS_SUCCESS:

--- a/src/modules/UI/Settings/reducer.js
+++ b/src/modules/UI/Settings/reducer.js
@@ -192,10 +192,18 @@ export const settings = (state = initialState, action) => {
   }
 
   case ACTION.TOUCH_ID_SETTINGS: {
-    return {
-      ...state,
-      isTouchSupported: data.isTouchSupported,
-      isTouchEnabled: data.isTouchEnabled
+    if (data) {
+      return {
+        ...state,
+        isTouchSupported: data.isTouchSupported,
+        isTouchEnabled: data.isTouchEnabled
+      }
+    } else {
+      return {
+        ...state,
+        isTouchSupported: false,
+        isTouchEnabled: false
+      }
     }
   }
 

--- a/src/modules/UI/Wallets/reducer.js
+++ b/src/modules/UI/Wallets/reducer.js
@@ -2,14 +2,20 @@
 
 import {combineReducers} from 'redux'
 import {GuiWallet} from '../../../types.js'
-import type {AbcDenomination, AbcMetaToken} from 'airbitz-core-types'
+import type {AbcDenomination, AbcMetaToken, AbcCurrencyWallet} from 'airbitz-core-types'
 import * as ACTION from './action'
 import * as ADD_TOKEN_ACTION from '../scenes/AddToken/action.js'
 import {UPDATE_WALLETS} from '../../Core/Wallets/action.js'
+import type {Action} from '../../ReduxTypes.js'
 
-export const byId = (state: any = {}, action: any) => {
-  const {type, data = {} } = action
-  switch (type) {
+export type WalletId = string
+export type WalletIds = Array<WalletId>
+export type WalletByIdState = {[walletId: WalletId]: GuiWallet}
+
+
+export const byId = (state: WalletByIdState = {}, action: Action) => {
+  if (!action.data) return state
+  switch (action.type) {
   case UPDATE_WALLETS: {
     const wallets = action.data.currencyWallets
     const out = {}
@@ -23,7 +29,7 @@ export const byId = (state: any = {}, action: any) => {
   case ACTION.UPSERT_WALLET:
     return {
       ...state,
-      [data.wallet.id]: schema(data.wallet)
+      [action.data.wallet.id]: schema(action.data.wallet)
     }
 
   default:
@@ -31,7 +37,8 @@ export const byId = (state: any = {}, action: any) => {
   }
 }
 
-export const activeWalletIds = (state: any = [], action: any) => {
+export const activeWalletIds = (state: WalletIds = [], action: Action) => {
+  if (!action.data) return state
   if (action.type === UPDATE_WALLETS) {
     return action.data.activeWalletIds
   }
@@ -39,7 +46,8 @@ export const activeWalletIds = (state: any = [], action: any) => {
   return state
 }
 
-export const archivedWalletIds = (state: any = [], action: any) => {
+export const archivedWalletIds = (state: WalletIds = [], action: Action) => {
+  if (!action.data) return state
   if (action.type === UPDATE_WALLETS) {
     return action.data.archivedWalletIds
   }
@@ -47,7 +55,8 @@ export const archivedWalletIds = (state: any = [], action: any) => {
   return state
 }
 
-export const selectedWalletId = (state: string = '', action: any) => {
+export const selectedWalletId = (state: WalletId = '', action: Action) => {
+  if (!action.data) return state
   switch (action.type) {
   case ACTION.SELECT_WALLET:
     return action.data.walletId
@@ -56,7 +65,8 @@ export const selectedWalletId = (state: string = '', action: any) => {
   }
 }
 
-export const selectedCurrencyCode = (state: string = '', action: any) => {
+export const selectedCurrencyCode = (state: string = '', action: Action) => {
+  if (!action.data) return state
   switch (action.type) {
   case ACTION.SELECT_WALLET:
     return action.data.currencyCode
@@ -65,7 +75,8 @@ export const selectedCurrencyCode = (state: string = '', action: any) => {
   }
 }
 
-const addTokenPending = (state = false, action) => {
+const addTokenPending = (state: boolean = false, action: Action) => {
+  if (!action.data) return state
   const type = action.type
   switch (type) {
   case ADD_TOKEN_ACTION.ADD_TOKEN_START :
@@ -77,7 +88,8 @@ const addTokenPending = (state = false, action) => {
   }
 }
 
-const manageTokensPending = (state = false, action) => {
+const manageTokensPending = (state: boolean = false, action: Action) => {
+  if (!action.data) return state
   const type = action.type
   switch (type) {
   case ACTION.MANAGE_TOKENS_START :
@@ -89,7 +101,7 @@ const manageTokensPending = (state = false, action) => {
   }
 }
 
-function schema (wallet: any): GuiWallet {
+function schema (wallet: AbcCurrencyWallet): GuiWallet {
   const id: string = wallet.id
   const type: string = wallet.type
   const name: string = wallet.name || 'no wallet name'

--- a/src/modules/UI/Wallets/reducer.js
+++ b/src/modules/UI/Wallets/reducer.js
@@ -48,24 +48,18 @@ export const archivedWalletIds = (state: any = [], action: any) => {
 }
 
 export const selectedWalletId = (state: string = '', action: any) => {
-  const {type, data = {} } = action
-  const {walletId} = data
-
-  switch (type) {
+  switch (action.type) {
   case ACTION.SELECT_WALLET:
-    return walletId
+    return action.data.walletId
   default:
     return state
   }
 }
 
 export const selectedCurrencyCode = (state: string = '', action: any) => {
-  const {type, data = {} } = action
-  const {currencyCode} = data
-
-  switch (type) {
+  switch (action.type) {
   case ACTION.SELECT_WALLET:
-    return currencyCode
+    return action.data.currencyCode
   default:
     return state
   }

--- a/src/modules/UI/components/TransactionAlert/reducer.js
+++ b/src/modules/UI/components/TransactionAlert/reducer.js
@@ -2,8 +2,10 @@
 
 import * as ACTIONS from './actions'
 import {combineReducers} from 'redux'
+import type {Action} from '../../../ReduxTypes.js'
+import type {AbcTransaction} from 'airbitz-core-types'
 
-const displayAlert = (state = false, action = {}) => {
+const displayAlert = (state: boolean = false, action: Action) => {
   const {type} = action
   switch (type) {
   case ACTIONS.DISPLAY_TRANSACTION_ALERT:
@@ -15,7 +17,9 @@ const displayAlert = (state = false, action = {}) => {
   }
 }
 
-const abcTransaction = (state = '', action = {}) => {
+type AbcTransactionState = AbcTransaction | ''
+
+const abcTransaction = (state: AbcTransactionState = '', action: Action) => {
   switch (action.type) {
   case ACTIONS.DISPLAY_TRANSACTION_ALERT:
     if (action.data) {

--- a/src/modules/UI/components/TransactionAlert/reducer.js
+++ b/src/modules/UI/components/TransactionAlert/reducer.js
@@ -16,10 +16,12 @@ const displayAlert = (state = false, action = {}) => {
 }
 
 const abcTransaction = (state = '', action = {}) => {
-  const {type, data: {abcTransaction} = {} } = action
-  switch (type) {
+  switch (action.type) {
   case ACTIONS.DISPLAY_TRANSACTION_ALERT:
-    return abcTransaction
+    if (action.data) {
+      return action.data.abcTransaction
+    }
+    return state
   case ACTIONS.DISMISS_TRANSACTION_ALERT:
     return ''
   default:

--- a/src/modules/UI/scenes/CreateWallet/reducer.js
+++ b/src/modules/UI/scenes/CreateWallet/reducer.js
@@ -2,33 +2,27 @@ import {combineReducers} from 'redux'
 import * as ACTION from './action'
 
 const walletName = (state = '', action) => {
-  const {type, data = {} } = action
-  const {walletName} = data
-  switch (type) {
+  switch (action.type) {
   case ACTION.UPDATE_WALLET_NAME :
-    return walletName
+    return action.data.walletName
   default:
     return state
   }
 }
 
 const selectedWalletType = (state = '', action) => {
-  const {type, data = {} } = action
-  const {walletType} = data
-  switch (type) {
+  switch (action.type) {
   case ACTION.SELECT_WALLET_TYPE:
-    return walletType
+    return action.data.walletType
   default:
     return state
   }
 }
 
 const selectedFiat = (state = '', action) => {
-  const {type, data = {} } = action
-  const {fiat} = data
-  switch (type) {
+  switch (action.type) {
   case ACTION.SELECT_FIAT:
-    return fiat
+    return action.data.fiat
   default:
     return state
   }

--- a/src/modules/UI/scenes/CreateWallet/reducer.js
+++ b/src/modules/UI/scenes/CreateWallet/reducer.js
@@ -1,16 +1,25 @@
+// @flow
+
 import {combineReducers} from 'redux'
 import * as ACTION from './action'
+import type {Action} from '../../../ReduxTypes.js'
 
-const walletName = (state = '', action) => {
+export type WalletNameState = string
+export type SelectedWalletTypeState = string
+export type SelectedFiatState = string
+
+const walletName = (state: WalletNameState = '', action: Action) => {
+  if (!action.data) return state
   switch (action.type) {
-  case ACTION.UPDATE_WALLET_NAME :
+  case ACTION.UPDATE_WALLET_NAME:
     return action.data.walletName
   default:
     return state
   }
 }
 
-const selectedWalletType = (state = '', action) => {
+const selectedWalletType = (state: SelectedWalletTypeState = '', action: Action) => {
+  if (!action.data) return state
   switch (action.type) {
   case ACTION.SELECT_WALLET_TYPE:
     return action.data.walletType
@@ -19,7 +28,8 @@ const selectedWalletType = (state = '', action) => {
   }
 }
 
-const selectedFiat = (state = '', action) => {
+const selectedFiat = (state: SelectedFiatState = '', action: Action) => {
+  if (!action.data) return state
   switch (action.type) {
   case ACTION.SELECT_FIAT:
     return action.data.fiat

--- a/src/modules/UI/scenes/TransactionList/reducer.js
+++ b/src/modules/UI/scenes/TransactionList/reducer.js
@@ -2,17 +2,18 @@
   import {combineReducers} from 'redux'
 
   const transactions = (state = [], action) => {
-    const {type, data = {} } = action
-    const {transactions} = data
-    switch (type) {
+    let transactions
+    switch (action.type) {
     case ACTION.UPDATE_TRANSACTIONS:
-      return transactions
+      return action.data.transactions
     case ACTION.NEW_TRANSACTIONS:
+      transactions = action.data.transactions
       return [
         ...state,
         ...transactions
       ]
     case ACTION.CHANGED_TRANSACTIONS:
+      transactions = action.data.transactions
       return [
         ...state,
         ...transactions

--- a/src/modules/UI/scenes/TransactionList/reducer.js
+++ b/src/modules/UI/scenes/TransactionList/reducer.js
@@ -1,76 +1,84 @@
-  import * as ACTION from './action'
-  import {combineReducers} from 'redux'
+// @flow
 
-  const transactions = (state = [], action) => {
-    let transactions
-    switch (action.type) {
-    case ACTION.UPDATE_TRANSACTIONS:
-      return action.data.transactions
-    case ACTION.NEW_TRANSACTIONS:
-      transactions = action.data.transactions
-      return [
-        ...state,
-        ...transactions
-      ]
-    case ACTION.CHANGED_TRANSACTIONS:
-      transactions = action.data.transactions
-      return [
-        ...state,
-        ...transactions
-      ]
-    default:
-      return state
-    }
+import * as ACTION from './action'
+import {combineReducers} from 'redux'
+import type {Action} from '../../../ReduxTypes.js'
+import type {AbcTransaction} from 'airbitz-core-types'
+
+export type TransactionsState = Array<AbcTransaction>
+export type ContactsListState = Array<any>
+
+const transactions = (state: TransactionsState = [], action: Action) => {
+  let transactions
+  if (!action.data) return state
+  switch (action.type) {
+  case ACTION.UPDATE_TRANSACTIONS:
+    return action.data.transactions
+  case ACTION.NEW_TRANSACTIONS:
+    transactions = action.data.transactions
+    return [
+      ...state,
+      ...transactions
+    ]
+  case ACTION.CHANGED_TRANSACTIONS:
+    transactions = action.data.transactions
+    return [
+      ...state,
+      ...transactions
+    ]
+  default:
+    return state
   }
+}
 
-  const searchVisible = (state = false, action) => {
-    switch (action.type) {
-    case ACTION.TRANSACTIONS_SEARCH_VISIBLE :
-      return true
-    case ACTION.TRANSACTIONS_SEARCH_HIDDEN :
-      return false
-    default:
-      return state
-    }
+const searchVisible = (state: boolean = false, action: Action) => {
+  switch (action.type) {
+  case ACTION.TRANSACTIONS_SEARCH_VISIBLE :
+    return true
+  case ACTION.TRANSACTIONS_SEARCH_HIDDEN :
+    return false
+  default:
+    return state
   }
+}
 
-  const contactsList = (state = [], action) => {
-    switch (action.type) {
-    case ACTION.UPDATE_CONTACTS_LIST :
-      return action.data
-    default:
-      return state
-    }
+const contactsList = (state: ContactsListState = [], action: Action) => {
+  switch (action.type) {
+  case ACTION.UPDATE_CONTACTS_LIST :
+    return action.data
+  default:
+    return state
   }
+}
 
-  const updatingBalance = (state = true, action) => {
-    switch (action.type) {
-    case ACTION.ENABLE_UPDATING_BALANCE :
-      return true
-    case ACTION.DISABLE_UPDATING_BALANCE :
-      return false
-    case ACTION.TOGGLE_UPDATING_BALANCE :
-      return !state
-    default :
-      return state
-    }
+const updatingBalance = (state: boolean = true, action) => {
+  switch (action.type) {
+  case ACTION.ENABLE_UPDATING_BALANCE :
+    return true
+  case ACTION.DISABLE_UPDATING_BALANCE :
+    return false
+  case ACTION.TOGGLE_UPDATING_BALANCE :
+    return !state
+  default :
+    return state
   }
+}
 
-  const transactionsWalletListModalVisibility = (state = false, action) => {
-    switch (action.type) {
-    case ACTION.TOGGLE_TRANSACTIONS_WALLET_LIST_MODAL :
-      return !state
-    default:
-      return state
-    }
+const transactionsWalletListModalVisibility = (state = false, action) => {
+  switch (action.type) {
+  case ACTION.TOGGLE_TRANSACTIONS_WALLET_LIST_MODAL :
+    return !state
+  default:
+    return state
   }
+}
 
-  const transactionList = combineReducers({
-    transactions,
-    searchVisible,
-    contactsList,
-    updatingBalance,
-    transactionsWalletListModalVisibility
-  })
+const transactionList = combineReducers({
+  transactions,
+  searchVisible,
+  contactsList,
+  updatingBalance,
+  transactionsWalletListModalVisibility
+})
 
-  export default transactionList
+export default transactionList

--- a/src/modules/UI/scenes/WalletList/reducer.js
+++ b/src/modules/UI/scenes/WalletList/reducer.js
@@ -1,7 +1,10 @@
+// @flow
+
 import * as ACTION from './action'
 import {combineReducers} from 'redux'
+import type {Action} from '../../../ReduxTypes.js'
 
-const renameWalletModalVisible = (state = false, action) => {
+const renameWalletModalVisible = (state: boolean = false, action: Action) => {
   const {type} = action
   switch (type) {
   case ACTION.OPEN_RENAME_WALLET_MODAL:
@@ -13,7 +16,7 @@ const renameWalletModalVisible = (state = false, action) => {
   }
 }
 
-const deleteWalletModalVisible = (state = false, action) => {
+const deleteWalletModalVisible = (state: boolean = false, action: Action) => {
   const {type} = action
   switch (type) {
   case ACTION.OPEN_DELETE_WALLET_MODAL:
@@ -25,7 +28,7 @@ const deleteWalletModalVisible = (state = false, action) => {
   }
 }
 
-const walletArchivesVisible = (state = false, action) => {
+const walletArchivesVisible = (state: boolean = false, action: Action) => {
   switch (action.type) {
   case ACTION.OPEN_WALLET_ARCHIVES:
     return true
@@ -36,7 +39,7 @@ const walletArchivesVisible = (state = false, action) => {
   }
 }
 
-const walletId = (state = '', action) => {
+const walletId = (state: string = '', action: Action) => {
   switch (action.type) {
   case ACTION.OPEN_DELETE_WALLET_MODAL:
   case ACTION.OPEN_RENAME_WALLET_MODAL:
@@ -52,7 +55,7 @@ const walletId = (state = '', action) => {
   }
 }
 
-const walletName = (state = '', action) => {
+const walletName = (state: string = '', action: Action) => {
   switch (action.type) {
   case ACTION.OPEN_RENAME_WALLET_MODAL:
     if (action.data && action.data.walletName) {
@@ -66,7 +69,7 @@ const walletName = (state = '', action) => {
   }
 }
 
-const renameWalletInput = (state = '', action) => {
+const renameWalletInput = (state: string = '', action: Action) => {
   switch (action.type) {
   case ACTION.UPDATE_RENAME_WALLET_INPUT:
     if (action.data && action.data.renameWalletInput) {

--- a/src/modules/UI/scenes/WalletList/reducer.js
+++ b/src/modules/UI/scenes/WalletList/reducer.js
@@ -37,12 +37,13 @@ const walletArchivesVisible = (state = false, action) => {
 }
 
 const walletId = (state = '', action) => {
-  const {type, data = {} } = action
-  const {walletId} = data
-  switch (type) {
+  switch (action.type) {
   case ACTION.OPEN_DELETE_WALLET_MODAL:
   case ACTION.OPEN_RENAME_WALLET_MODAL:
-    return walletId
+    if (action.data) {
+      return action.data.walletId
+    }
+    return state
   case ACTION.CLOSE_DELETE_WALLET_MODAL:
   case ACTION.CLOSE_RENAME_WALLET_MODAL:
     return ''
@@ -52,11 +53,12 @@ const walletId = (state = '', action) => {
 }
 
 const walletName = (state = '', action) => {
-  const {type, data = {} } = action
-  const {walletName} = data
-  switch (type) {
+  switch (action.type) {
   case ACTION.OPEN_RENAME_WALLET_MODAL:
-    return walletName || 'Wallet Name'
+    if (action.data && action.data.walletName) {
+      return walletName
+    }
+    return 'Wallet Name'
     // case ACTION.CLOSE_RENAME_WALLET_MODAL:
     //   return ''
   default:
@@ -65,11 +67,12 @@ const walletName = (state = '', action) => {
 }
 
 const renameWalletInput = (state = '', action) => {
-  const {type, data = {} } = action
-  const {renameWalletInput} = data
-  switch (type) {
+  switch (action.type) {
   case ACTION.UPDATE_RENAME_WALLET_INPUT:
-    return renameWalletInput || ''
+    if (action.data && action.data.renameWalletInput) {
+      return renameWalletInput
+    }
+    return ''
   case ACTION.CLOSE_RENAME_WALLET_MODAL:
   case ACTION.RENAME_WALLET:
     return ''


### PR DESCRIPTION
Do not dereference action.data before the case statement of a reducer as the data may be NULL.
For ACTION.TOUCH_ID_SETTINGS, also check for data == NULL because the core-js-ui might pass a NULL touchIdInfo object