### PR TITLE
URGENT: Fix crash due to enabled custom tokens

### DIFF
--- a/src/modules/UI/Wallets/action.js
+++ b/src/modules/UI/Wallets/action.js
@@ -131,6 +131,7 @@ export const getEnabledTokens = (walletId: string) => async (dispatch: Dispatch,
   try {
     const enabledTokens = await WALLET_API.getEnabledTokensFromFile(wallet)
     const promiseArray = []
+    const tokensToEnable = []
 
     // Add any enabledTokens that are custom tokens
     for (const ct of customTokens) {
@@ -138,12 +139,13 @@ export const getEnabledTokens = (walletId: string) => async (dispatch: Dispatch,
         return element === ct.currencyCode
       })
       if (found) {
+        tokensToEnable.push(found)
         promiseArray.push(wallet.addCustomToken(ct))
       }
     }
     await Promise.all(promiseArray)
     // now reflect that change in Redux's version of the wallet
-    dispatch(updateWalletEnabledTokens(walletId, enabledTokens))
+    dispatch(updateWalletEnabledTokens(walletId, tokensToEnable))
   } catch (e) {
     dispatch(displayErrorAlert(e.message))
   }


### PR DESCRIPTION
Do not enable any tokens that are marked enabled in the wallet file if they are not also in the accounts token file. The account contains the details of the custom token, which we cannot work without.

This fixes very easy to reproduce crashes due to out-of-sync account data and wallet data which can easily happen right now as we do not git sync very often.