### PR TITLE
Fix wallet rename causing spinning wallet reload

### DIFF
--- a/src/modules/UI/scenes/WalletList/WalletList.ui.js
+++ b/src/modules/UI/scenes/WalletList/WalletList.ui.js
@@ -86,7 +86,7 @@ type Props = {
   wallets: any,
   closeDeleteWalletModal: () => void,
   closeRenameWalletModal: () => void,
-  renameWalletInput: () => void,
+  renameWalletInput: string,
   setContactList: (Array<GuiContact>) => void,
   updateArchivedWalletsOrder: (Array<string>) => void,
   updateActiveWalletsOrder: (Array<string>) => void,

--- a/src/modules/UI/scenes/WalletList/components/RenameWalletButtonsConnector.js
+++ b/src/modules/UI/scenes/WalletList/components/RenameWalletButtonsConnector.js
@@ -13,7 +13,7 @@ const mapStateToProps = (state: State): StateToProps => ({
 })
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
   onNegative: () => {},
-  onPositive: (walletId, walletName) => dispatch(renameWallet(walletId, walletName)),
+  onPositive: (walletId: string, walletName: string) => dispatch(renameWallet(walletId, walletName)),
   onDone: () => dispatch(closeRenameWalletModal()),
 })
 

--- a/src/modules/UI/scenes/WalletList/reducer.js
+++ b/src/modules/UI/scenes/WalletList/reducer.js
@@ -59,7 +59,7 @@ const walletName = (state: string = '', action: Action) => {
   switch (action.type) {
   case ACTION.OPEN_RENAME_WALLET_MODAL:
     if (action.data && action.data.walletName) {
-      return walletName
+      return action.data.walletName
     }
     return 'Wallet Name'
     // case ACTION.CLOSE_RENAME_WALLET_MODAL:
@@ -73,7 +73,7 @@ const renameWalletInput = (state: string = '', action: Action) => {
   switch (action.type) {
   case ACTION.UPDATE_RENAME_WALLET_INPUT:
     if (action.data && action.data.renameWalletInput) {
-      return renameWalletInput
+      return action.data.renameWalletInput
     }
     return ''
   case ACTION.CLOSE_RENAME_WALLET_MODAL:


### PR DESCRIPTION
Previous refactor of reducers caused return payload to return actual reducer function vs the payload data. Another error that proper flow typing would have caught.