### PR TITLE
Fix disappearing token subwallets

### DIFF
--- a/src/modules/Core/Wallets/api.js
+++ b/src/modules/Core/Wallets/api.js
@@ -66,13 +66,15 @@ export const addCoreCustomToken = (wallet: AbcCurrencyWallet, tokenObj: any) => 
   .catch((e) => console.log(e))
 }
 
-export const getEnabledTokensFromFile = (wallet: AbcCurrencyWallet): Promise<Array<any>> => {
-  return getEnabledTokensFile(wallet).getText()
-  .then(JSON.parse)
-  .catch((e) => {
+export const getEnabledTokensFromFile = async (wallet: AbcCurrencyWallet): Promise<Array<any>> => {
+  try {
+    const tokensText = await getEnabledTokensFile(wallet).getText()
+    const tokens = JSON.parse(tokensText)
+    return tokens
+  } catch (e) {
     console.log(e)
     return setEnabledTokens(wallet, [])
-  })
+  }
 }
 
 export const getEnabledTokensFile = (wallet: AbcCurrencyWallet) => {
@@ -102,11 +104,10 @@ export async function updateEnabledTokens (wallet: AbcCurrencyWallet, tokensToEn
     const enabledTokens = JSON.parse(tokensText)
     let tokensWithNewTokens = _.union(tokensToEnable, enabledTokens)
     let finalTokensToEnable = _.difference(tokensWithNewTokens, tokensToDisable)
-    return Promise.all([
-      enableTokens(wallet, finalTokensToEnable),
-      disableTokens(wallet, tokensToDisable),
-      tokensFile.setText(JSON.stringify(finalTokensToEnable))
-    ])
+    await enableTokens(wallet, finalTokensToEnable)
+    await disableTokens(wallet, tokensToDisable)
+    console.log('updateEnabledTokens setText', finalTokensToEnable)
+    await tokensFile.setText(JSON.stringify(finalTokensToEnable))
   } catch (e) {
     console.log(e)
   }

--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -39,8 +39,6 @@ export const initializeAccount = (account: AbcAccount, touchIdInfo: Object) => (
       dispatch(ACCOUNT_ACTIONS.addAccount(account))
       dispatch(SETTINGS_ACTIONS.setLoginStatus(true))
       // TODO: understand why this fails flow -paulvp
-      // $FlowFixMe
-      dispatch(updateWalletsRequest())
 
       if (ACCOUNT_API.checkForExistingWallets(account)) {
         const {walletId, currencyCode} = ACCOUNT_API.getFirstActiveWalletInfo(account, currencyCodes)
@@ -54,6 +52,8 @@ export const initializeAccount = (account: AbcAccount, touchIdInfo: Object) => (
         false, true
       ))
       dispatch(loadSettings())
+      // $FlowFixMe
+      dispatch(updateWalletsRequest())
     })
 }
 


### PR DESCRIPTION
1. On login, call updateWalletRequest() after loadSettings so we have all the custom token info loaded off disk before we initialize the subwallets
2. Fix getEnabledTokens to also enable tokens from the currencyInfo
3. Clean up getEnabledTokensFromFile to use async/await and be easier to debug