### PR TITLE
Fix spinning wallets on login

### DIFF
--- a/src/modules/Login/action.js
+++ b/src/modules/Login/action.js
@@ -44,6 +44,8 @@ export const initializeAccount = (account: AbcAccount, touchIdInfo: Object) => (
         const {walletId, currencyCode} = ACCOUNT_API.getFirstActiveWalletInfo(account, currencyCodes)
         dispatch(WALLET_ACTIONS.selectWallet(walletId, currencyCode))
         dispatch(loadSettings())
+        // $FlowFixMe
+        dispatch(updateWalletsRequest())
         return
       }
       dispatch(actions.createCurrencyWallet(


### PR DESCRIPTION
Call updateWalletsRequest() upon login even in the case when we have existing wallets