### PR TITLE
Make Exchange Change Mining Fee Header Transparent

### DIFF
--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -294,7 +294,7 @@ export default class Main extends Component<Props, State> {
                             renderTitle={this.renderTitle(EXCHANGE)}
                             renderLeftButton={this.renderExchangeButton}
                             renderRightButton={this.renderMenuButton} />
-                          <Scene key={Constants.CHANGE_MINING_FEE_EXCHANGE}
+                          <Scene key={Constants.CHANGE_MINING_FEE_EXCHANGE} navTransparent={true}
                             component={ChangeMiningFeeExchange}
                             renderTitle={this.renderTitle(CHANGE_MINING_FEE)}
                             renderLeftButton={this.renderBackButton()}


### PR DESCRIPTION
The purpose of this task was to fix the appearance of the **Exchange Scene**'s "Change Mining Fee" scene **header**. The fix was as simple as making the otherwise-white header transparent (one-line fix).

Asana Task: https://app.asana.com/0/361770107085503/514704167771592/f