### PR TITLE
Fix missing REP from showing in wallet list dropdown

### DIFF
--- a/src/modules/UI/components/WalletListModal/components/WalletListModalBody.ui.js
+++ b/src/modules/UI/components/WalletListModal/components/WalletListModalBody.ui.js
@@ -43,7 +43,8 @@ export default class WalletListModalBody extends Component<$FlowFixMeProps> {
     const tokens = []
     for (const property in metaTokenBalances) {
       if (property !== code) {
-        if (_.findIndex(combinedTokens, (token) => token.currencyCode === property)) {
+        const index = _.findIndex(combinedTokens, (token) => token.currencyCode === property)
+        if (index !== -1) {
           tokens.push(this.renderTokenRowContent(walletId, property, metaTokenBalances[property]))
         }
       }


### PR DESCRIPTION
Properly accept token if find() return 0. Only -1 means array element not found