### PR TITLE
Fix choppy scene issue on initial load to CreateWalletName

### DIFF
--- a/src/modules/UI/scenes/CreateWallet/CreateWalletName.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletName.ui.js
@@ -102,7 +102,6 @@ class WalletNameInput extends Component<WalletNameInputProps> {
         <FormField style={MaterialInputOnWhite}
           clearButtonMode={'while-editing'}
           autoCorrect={false}
-          autoFocus
           placeholder={this.props.placeholder}
           onChangeText={this.props.onChangeText}
           label={s.strings.fragment_wallets_addwallet_name_hint}


### PR DESCRIPTION
The purpose of this task is to prevent the choppy animation / transition that occurs upon initial load when you try to create a wallet. The issues appears to be caused by the `autofocus` property for the FormField being set to true. I have disabled the autoFocus for the time being.

Asana Task: https://app.asana.com/0/361770107085503/523972073634899/f