### PR TITLE
Re-implement alert for blank / invalid CreateWallet data

### DIFF
--- a/src/modules/UI/scenes/CreateWallet/CreateWalletName.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletName.ui.js
@@ -75,7 +75,6 @@ export class CreateWalletNameComponent extends Component<CreateWalletNameProps, 
 
             <PrimaryButton
               style={[styles.next]}
-              disabled={!this.state.walletName}
               onPressFunction={this.onNext}
               text={s.strings.string_next_capitalized}
               processingElement={<ActivityIndicator />}

--- a/src/modules/UI/scenes/CreateWallet/CreateWalletSelectCrypto.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletSelectCrypto.ui.js
@@ -111,7 +111,6 @@ export class CreateWalletSelectCryptoComponent extends Component<CreateWalletSel
       return ((entry.label.toLowerCase().indexOf(this.state.searchTerm.toLowerCase()) >= 0) ||
               (entry.currencyCode.toLowerCase().indexOf(this.state.searchTerm.toLowerCase()) >= 0))
     })
-    const isDisabled = !this.isValidWalletType()
     const keyboardHeight = this.props.dimensions.keyboardHeight || 0
     const searchResultsHeight = PLATFORM.usableHeight - keyboardHeight - 50 - 58 // substract button area height and FormField height
 
@@ -146,7 +145,6 @@ export class CreateWalletSelectCryptoComponent extends Component<CreateWalletSel
 
             <PrimaryButton
               style={[styles.next]}
-              disabled={isDisabled}
               onPressFunction={this.onNext}
               text={s.strings.string_next_capitalized}
             />

--- a/src/modules/UI/scenes/CreateWallet/CreateWalletSelectFiat.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletSelectFiat.ui.js
@@ -118,7 +118,6 @@ export class CreateWalletSelectFiatComponent extends Component<CreateWalletSelec
     const filteredArray = this.props.supportedFiats.filter((entry) => {
       return (entry.label.toLowerCase().indexOf(this.state.searchTerm.toLowerCase()) >= 0)
     })
-    const isDisabled = !this.isValidFiatType()
     const keyboardHeight = this.props.dimensions.keyboardHeight || 0
     const searchResultsHeight = PLATFORM.usableHeight - keyboardHeight - 50 - 58 // substract button area height and FormField height
 
@@ -155,7 +154,6 @@ export class CreateWalletSelectFiatComponent extends Component<CreateWalletSelec
 
             <PrimaryButton
               style={[styles.next]}
-              disabled={isDisabled}
               onPressFunction={this.onNext}
               text={s.strings.string_next_capitalized}
             />


### PR DESCRIPTION
The purpose of this task is to re-enable the alert(s) that show up when invalid data is present while pressing "Next" in the Create Wallet process. This includes the Wallet Name, Wallet Type (Crypto), and Wallet Fiat Type. The issue appeared to be that the "Next" button was disabled while data was invalid, so the `onNext` callback (which triggers the alert) was not being called.

All three of the following tasks are handled by this PR:
https://app.asana.com/0/361770107085503/523972073634902/f
https://app.asana.com/0/361770107085503/523972073634901/f
https://app.asana.com/0/361770107085503/523972073634900/f

