### PR TITLE
Android: fix locale - set en-US

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "https-browserify": "0.0.1",
     "intl": "^1.2.5",
+    "intl-locales-supported": "^1.0.0",
     "lodash": "^4.17.2",
     "native-base": "^2.2.1",
     "os-browserify": "^0.1.2",

--- a/src/locales/intl.js
+++ b/src/locales/intl.js
@@ -1,6 +1,8 @@
 // @flow
 /* global Intl */
 import 'intl'
+import 'intl/locale-data/jsonp/en-US'
+import {Platform} from 'react-native'
 
 const decimalSeparatorNative = '.'
 const EN_US_LOCALE = {
@@ -141,7 +143,11 @@ const intlHandler = {
 
 export const setIntlLocale = (l: IntlLocaleType) => {
   if (!locale) throw new Error('Please select locale for internationalization')
-  locale = l
+  if (Platform.OS !== 'ios') {
+    locale = EN_US_LOCALE
+  } else {
+    locale = l
+  }
   return intlHandler
 }
 export { intlHandler as intl }

--- a/src/locales/intl.js
+++ b/src/locales/intl.js
@@ -1,8 +1,12 @@
 // @flow
 /* global Intl */
 import 'intl'
+import areIntlLocalesSupported from 'intl-locales-supported'
+
+// Polyfills for Android. Now support only these locales. en-US is fallback
 import 'intl/locale-data/jsonp/en-US'
-import {Platform} from 'react-native'
+import 'intl/locale-data/jsonp/de-DE'
+import 'intl/locale-data/jsonp/ru-RU'
 
 const decimalSeparatorNative = '.'
 const EN_US_LOCALE = {
@@ -143,7 +147,9 @@ const intlHandler = {
 
 export const setIntlLocale = (l: IntlLocaleType) => {
   if (!locale) throw new Error('Please select locale for internationalization')
-  if (Platform.OS !== 'ios') {
+  const localeIdentifier = l.localeIdentifier.replace('_', '-')
+
+  if (!areIntlLocalesSupported(localeIdentifier)) {
     locale = EN_US_LOCALE
   } else {
     locale = l

--- a/src/locales/intl.test.js
+++ b/src/locales/intl.test.js
@@ -1,6 +1,9 @@
-/* globals describe test expect beforeEach */
+/* globals describe test expect beforeEach jest */
+/* eslint-disable import/first */
 import {intl, setIntlLocale} from './intl'
 import { truncateDecimals } from '../../src/modules/utils'
+
+jest.mock('intl-locales-supported', () => () => (true))
 
 const EN_US_LOCALE = {
   'localeIdentifier': 'en_US',

--- a/src/modules/UI/components/FlipInput/FlipInput.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput.ui.js
@@ -134,7 +134,7 @@ export default class FlipInput extends Component<Props, State> {
         <TextInput style={[top.amount, (Platform.OS === 'ios') ? {} : {paddingBottom: 2}]}
           placeholder={'0'}
           placeholderTextColor={'rgba(255, 255, 255, 0.60)'}
-          value={intl.formatNumberInput(amount)}
+          value={amount}
           onChangeText={onChangeText}
           autoCorrect={false}
           keyboardType='numeric'


### PR DESCRIPTION
Add fallback locale-data as locale `en-US` for android. Figured out that with other locales polyfill has issue in FlipInput. Will work on it.

**EDIT:** Fixed FlipInput issue. Added 3 locales (en, de, ru). Used `en-US` as fallback if we don't have `locale-data` for user locale. 
Adding more polyfill-locales (mostly for Android) can be provided with simple importing `locale-data`, like
```
import 'intl/locale-data/jsonp/ru-RU'
```