### PR TITLE
Fix not scrolling of the wallet list when on iPhone X

### DIFF
--- a/src/modules/UI/scenes/WalletList/style.js
+++ b/src/modules/UI/scenes/WalletList/style.js
@@ -171,7 +171,7 @@ export const styles = {
   },
   fullList: {
     flex: 1,
-    position: 'absolute',
+    // position: 'absolute',
     height: platform.usableHeight - 130 - 50
   },
   rowContainer: {


### PR DESCRIPTION
Also only commented out the style because i'm not sure what it does, checked all the platforms and working fine. 