### PR TITLE
Request Scene. Balance will revert back to 0 when currency wallet is …

### DIFF
--- a/src/modules/UI/components/FlipInput/FlipInput.ui.js
+++ b/src/modules/UI/components/FlipInput/FlipInput.ui.js
@@ -120,6 +120,9 @@ export default class FlipInput extends Component<Props, State> {
         secondaryDisplayAmount: UTILS.truncateDecimals(nextProps.secondaryDisplayAmount, 2)
       })
     }
+    if (nextProps.primaryInfo.displayCurrencyCode !== this.props.primaryInfo.displayCurrencyCode) {
+      setTimeout(() => this.onPrimaryAmountChange('0'), 50)
+    }
   }
 
   onPrimaryAmountChange = (primaryDisplayAmount: string) => {


### PR DESCRIPTION
…changed

NOTICE BEFORE APPROVAL

I needed to **add a setTimeout** here because there seems to be a a bug when changing to ethereum wallet. Did check how the code works and nothing I see that should affect computation of conversion. 

Error comes from IndexEthereum.js: 1840: 16

Attached error file:
<img width="387" alt="screen shot 2018-01-26 at 10 57 09 pm" src="https://user-images.githubusercontent.com/17136567/35445643-3ac7c1ee-02ed-11e8-9472-82a2998a6710.png">
