### PR TITLE
Fix saving transaction details

### DIFF
--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -372,7 +372,7 @@ export class TransactionDetails extends Component<Props & DispatchProps, State> 
     const newAmountFiat = this.state.amountFiat
     const amountFiat:number = (!newAmountFiat) ? 0.00 : Number.parseFloat(newAmountFiat)
     const abcMetadata: AbcMetadata = {name, category, notes, amountFiat, bizId, miscJson}
-    this.props.setTransactionDetails(txid, this.guiWallet.currencyCode, abcMetadata)
+    this.props.setTransactionDetails(txid, this.props.abcTransaction.currencyCode, abcMetadata)
   }
 
   componentDidMount () {


### PR DESCRIPTION
* Previously, transaction details would be saved to the parent currency
* This change saves the transaction details in the currency of the
transaction