### PR TITLE
Update new custom token enabled status upon successful addition

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -33,6 +33,7 @@ const strings = {
   addtoken_invalid_information: 'Please enter valid token information and try again',
   addtoken_denomination_input_text: 'Number of Decimal Places',
   addtoken_name_input_text: 'Token Name',
+  addtoken_add: 'Add',
   edittoken_top_instructions: 'Fill out token info and tap \'Save\' to edit token:',
   edittoken_delete_token: 'Delete Token',
   edittoken_delete_prompt: 'Are you sure you want to delete this token?',

--- a/src/modules/UI/scenes/AddToken/AddToken.ui.js
+++ b/src/modules/UI/scenes/AddToken/AddToken.ui.js
@@ -42,7 +42,8 @@ export type Props = {
   addTokenPending: Function,
   addNewToken: Function,
   currentCustomTokens: Array<CustomTokenInfo>,
-  wallet: GuiWallet
+  wallet: GuiWallet,
+  onAddToken: (string) => void
 }
 
 class AddToken extends Component<Props, State> {
@@ -166,6 +167,7 @@ class AddToken extends Component<Props, State> {
       if (currencyName && currencyCode && decimalPlaces && contractAddress) {
         const denomination = decimalPlacesToDenomination(decimalPlaces)
         this.props.addNewToken(walletId, currencyName, currencyCode, contractAddress, denomination)
+        this.props.onAddToken(currencyCode)
       } else {
         Alert.alert(s.strings.addtoken_invalid_information)
       }

--- a/src/modules/UI/scenes/ManageTokens/ManageTokens.ui.js
+++ b/src/modules/UI/scenes/ManageTokens/ManageTokens.ui.js
@@ -15,6 +15,7 @@ import Gradient from '../../components/Gradient/Gradient.ui'
 import ManageTokenRow from './ManageTokenRow.ui.js'
 import {PrimaryButton, SecondaryButton} from '../../components/Buttons'
 import styles from './style.js'
+import _ from 'lodash'
 
 export type Props = {
   guiWallet: GuiWallet,
@@ -22,7 +23,6 @@ export type Props = {
   settingsCustomTokens: Array<CustomTokenInfo>
 }
 export type DispatchProps = {
-  getEnabledTokensList: (string) => void,
   setEnabledTokensList: (string, Array<string>, Array<string>) => void
 }
 export type State = {
@@ -103,11 +103,11 @@ export default class ManageTokens extends Component<Props & DispatchProps, State
               <View style={[styles.buttonsArea]}>
                 <SecondaryButton
                   style={[styles.addButton]}
-                  text={'Add'}
+                  text={s.strings.addtoken_add}
                   onPressFunction={this.goToAddTokenScene}
                 />
                 <PrimaryButton
-                  text={'Save'}
+                  text={s.strings.string_save}
                   style={[styles.saveButton]}
                   onPressFunction={this.saveEnabledTokenList}
                   processingElement={<ActivityIndicator />}
@@ -136,9 +136,16 @@ export default class ManageTokens extends Component<Props & DispatchProps, State
     )
   }
 
+  _onAddToken = (currencyCode: string) => {
+    const newEnabledList = _.union(this.state.enabledList, [currencyCode])
+    this.setState({
+      enabledList: newEnabledList
+    })
+  }
+
   goToAddTokenScene = () => {
     const { id, metaTokens } = this.props.guiWallet
-    Actions.addToken({walletId: id, metaTokens})
+    Actions.addToken({walletId: id, metaTokens, onAddToken: this._onAddToken})
   }
 
   goToEditTokenScene = (currencyCode: string) => {

--- a/src/modules/UI/scenes/ManageTokens/ManageTokensConnector.js
+++ b/src/modules/UI/scenes/ManageTokens/ManageTokensConnector.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux'
 
 import ManageTokens from './ManageTokens.ui.js'
 
-import {getEnabledTokens, setEnabledTokens} from '../../Wallets/action.js'
+import {setEnabledTokens} from '../../Wallets/action.js'
 import type {GuiWallet, CustomTokenInfo} from '../../../../types'
 import type {State} from '../../../ReduxTypes'
 
@@ -14,7 +14,6 @@ export type StateProps = {
   settingsCustomTokens: Array<CustomTokenInfo>
 }
 export type DispatchProps = {
-  getEnabledTokensList: (string) => void,
   setEnabledTokensList: (string, Array<string>, Array<string>) => void
 }
 export type OwnProps = {guiWallet: GuiWallet}
@@ -25,7 +24,6 @@ const mapStateToProps = (state: State, ownProps: OwnProps): StateProps => ({
   settingsCustomTokens: state.ui.settings.customTokens
 })
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
-  getEnabledTokensList: (walletId: string) => dispatch(getEnabledTokens(walletId)),
   setEnabledTokensList: (walletId: string, enabledTokens: Array<string>, oldEnabledTokensList: Array<string>) => dispatch(setEnabledTokens(walletId, enabledTokens, oldEnabledTokensList))
 })
 export default connect(mapStateToProps, mapDispatchToProps)(ManageTokens)


### PR DESCRIPTION
The purpose of this task is to show a newly added custom token as *enabled* (ie checkmark in the box of the ManageTokens scene) immediately after the custom token has been added successfully.

https://app.asana.com/0/361770107085503/521515139317756/f