### PR TITLE
Fix flow errors from core typing AbcCurrencyWallet

### DIFF
--- a/src/modules/Core/Wallets/api.js
+++ b/src/modules/Core/Wallets/api.js
@@ -136,7 +136,7 @@ export const resyncWallet = (wallet: AbcCurrencyWallet): Promise<void> => {
 }
 
 export const getDisplayPrivateSeed = (wallet: AbcCurrencyWallet): string => {
-  return wallet.getDisplayPrivateSeed()
+  return wallet.getDisplayPrivateSeed() || 'receive-only wallet'
 }
 
 // Documented but not implemented in the core

--- a/src/modules/Core/selectors.js
+++ b/src/modules/Core/selectors.js
@@ -62,7 +62,9 @@ export const getFakeExchangeRate = (state: State, fromCurrencyCode: string, toCu
 }
 
 // Wallets
-export const getWallets = (state: State): AbcCurrencyWallet => {
+export const getWallets = (
+  state: State
+): { [walletId: string]: AbcCurrencyWallet } => {
   const core = getCore(state)
   const wallets = core.wallets.byId
   return wallets
@@ -76,7 +78,7 @@ export const getWallet = (state: State, walletId: string): AbcCurrencyWallet => 
 
 export const getWalletName = (state: State, walletId: string): string => {
   const wallet = getWallet(state, walletId)
-  return wallet && wallet.name
+  return (wallet && wallet.name) || 'no wallet name'
 }
 
 export const getBalanceInCrypto = (state: State, walletId: string, currencyCode: string) => {

--- a/src/modules/UI/Wallets/reducer.js
+++ b/src/modules/UI/Wallets/reducer.js
@@ -248,11 +248,12 @@ function schema (wallet: AbcCurrencyWallet): GuiWallet {
   const currencyCode: string = wallet.currencyInfo.currencyCode
   const fiatCurrencyCode: string = wallet.fiatCurrencyCode.replace('iso:', '')
   const isoFiatCurrencyCode: string = wallet.fiatCurrencyCode
-  const symbolImage: string = wallet.currencyInfo.symbolImage
-  const symbolImageDarkMono: string = wallet.currencyInfo.symbolImageDarkMono
+  const symbolImage = wallet.currencyInfo.symbolImage
+  const symbolImageDarkMono = wallet.currencyInfo.symbolImageDarkMono
   const metaTokens: Array<AbcMetaToken> = wallet.currencyInfo.metaTokens
   const denominations: Array<AbcDenomination> = wallet.currencyInfo.denominations
-  const enabledTokens: Array<string> = wallet.enabledTokens || []
+  // TODO: Fetch the token list asynchonously before dispatching `schema`:
+  const enabledTokens: Array<string> = []
 
   const allDenominations: {
     [currencyCode: string]: { [denomination: string]: AbcDenomination }

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -68,7 +68,9 @@ export class Request extends Component<Props, State> {
 
   componentWillReceiveProps (nextProps: Props) {
     if (nextProps.abcWallet && (!this.props.abcWallet || nextProps.abcWallet.id !== this.props.abcWallet.id)) {
-      const {abcWallet, currencyCode} = nextProps
+      const abcWallet: AbcCurrencyWallet | null = nextProps.abcWallet
+      const {currencyCode} = nextProps
+      if (!abcWallet) return
       WALLET_API.getReceiveAddress(abcWallet, currencyCode)
       .then((receiveAddress) => {
         const {publicAddress} = receiveAddress
@@ -87,8 +89,9 @@ export class Request extends Component<Props, State> {
   }
 
   componentDidMount () {
-    const {abcWallet, currencyCode} = this.props
-    if (this.props.loading) return
+    const {currencyCode} = this.props
+    const abcWallet: AbcCurrencyWallet | null = this.props.abcWallet
+    if (!abcWallet || this.props.loading) return
 
     WALLET_API.getReceiveAddress(abcWallet, currencyCode)
     .then((receiveAddress) => {
@@ -107,9 +110,11 @@ export class Request extends Component<Props, State> {
   }
 
   onExchangeAmountChanged = (amounts: ExchangedFlipInputAmounts) => {
-    const parsedURI = {
-      publicAddress: this.state.publicAddress,
-      nativeAmount: bns.gt(amounts.nativeAmount, '0') ? amounts.nativeAmount : null
+    const parsedURI: AbcEncodeUri = {
+      publicAddress: this.state.publicAddress
+    }
+    if (bns.gt(amounts.nativeAmount, '0')) {
+      parsedURI.nativeAmount = amounts.nativeAmount
     }
     const encodedURI = this.props.abcWallet ? this.props.abcWallet.encodeUri(parsedURI) : ''
 

--- a/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
+++ b/src/modules/UI/scenes/TransactionDetails/TransactionDetails.ui.js
@@ -40,7 +40,7 @@ export type Props = {
   thumbnailPath: string,
   currencyInfo: AbcCurrencyInfo | null,
   currencyCode: string,
-  wallets: Array<GuiWallet>
+  wallets: { [walletId: string]: GuiWallet }
 }
 
 export type DispatchProps = {

--- a/src/modules/UI/scenes/WalletList/action.js
+++ b/src/modules/UI/scenes/WalletList/action.js
@@ -3,9 +3,6 @@
 import type {Dispatch, GetState} from '../../../ReduxTypes'
 
 import * as ACCOUNT_API from '../../../Core/Account/api.js'
-import * as UI_ACTIONS from '../../Wallets/action.js'
-
-import * as CORE_SELECTORS from '../../../Core/selectors.js'
 
 export const TOGGLE_ARCHIVE_VISIBILITY = 'TOGGLE_ARCHIVE_VISIBILITY'
 
@@ -26,13 +23,6 @@ export const updateActiveWalletsOrder = (activeWalletIds: Array<string>) => (dis
       dispatch(wrap(UPDATE_ACTIVE_WALLETS_ORDER_SUCCESS, {activeWalletIds}))
     })
     .catch((e) => console.log(e))
-}
-
-export const updateIndividualWalletSortIndex = (walletId: string, sortIndex: number) => (dispatch: Dispatch, getState: GetState) => {
-  const state = getState()
-  const wallet = CORE_SELECTORS.getWallet(state, walletId)
-  wallet.sortIndex = sortIndex
-  return dispatch(UI_ACTIONS.upsertWallet(wallet))
 }
 
 export const updateArchivedWalletsOrder = (archivedWalletIds: Array<string>) => (dispatch: Dispatch, getState: GetState) => {

--- a/src/types.js
+++ b/src/types.js
@@ -17,8 +17,8 @@ export type GuiWallet = {
   fiatCurrencyCode: string,
   denominations: Array<AbcDenomination>,
   allDenominations: { [currencyCode: string]: { [denomination: string]: AbcDenomination } },
-  symbolImage: string,
-  symbolImageDarkMono: string,
+  symbolImage: string | void,
+  symbolImageDarkMono: string | void,
   metaTokens: Array<AbcMetaToken>,
   enabledTokens: Array<string>
 }


### PR DESCRIPTION
The core has a branch, `currency-wallet-flow`, that adds proper types for `AbcCurrencyWallet`. Merging that branch causes lots of errors in the GUI. This pull request fixes those.