### PR TITLE
Fix missing touchId entry in Settings.

### DIFF
--- a/src/modules/UI/Settings/action.js
+++ b/src/modules/UI/Settings/action.js
@@ -135,7 +135,7 @@ export const addTouchIdInfo = (touchIdInfo) => {
 export const updateTouchIdEnabled = (bool) => {
   return {
     type: CHANGE_TOUCH_ID_SETTINGS,
-    data: bool
+    data: { isTouchEnabled: bool }
   }
 }
 

--- a/src/modules/UI/Settings/reducer.js
+++ b/src/modules/UI/Settings/reducer.js
@@ -59,7 +59,7 @@ type SettingsState = {
   customTokens: Array<CustomTokenInfo>,
   defaultFiat: string,
   isOtpEnabled: boolean,
-  isTouchEnabled: any,
+  isTouchEnabled: boolean,
   isTouchSupported: boolean,
   loginStatus: null,
   merchantMode: boolean,
@@ -132,6 +132,7 @@ export const settings = (state: SettingsState = initialState, action: Action) =>
   switch (type) {
     case Constants.ACCOUNT_INIT_COMPLETE: {
       const {
+        touchIdInfo,
         account,
         loginStatus,
         otpInfo,
@@ -152,6 +153,8 @@ export const settings = (state: SettingsState = initialState, action: Action) =>
         isOtpEnabled: otpInfo.enabled,
         otpKey: otpInfo.otpKey,
         autoLogoutTimeInSeconds,
+        isTouchEnabled: touchIdInfo.isTouchEnabled,
+        isTouchSupported: touchIdInfo.isTouchSupported,
         defaultFiat,
         merchantMode,
         customTokens,
@@ -427,7 +430,7 @@ export const settings = (state: SettingsState = initialState, action: Action) =>
     case ACTION.CHANGE_TOUCH_ID_SETTINGS: {
       return {
         ...state,
-        isTouchEnabled: data
+        isTouchEnabled: data.isTouchEnabled
       }
     }
 


### PR DESCRIPTION
Settings reducer was not properly setting the isTouchIdEnabled and isTouchSupported booleans. This broke with the major login refactor.
Fix incorrect Flow type as isTouchEnabled is a boolean not Object/any