### PR TITLE
Fix EditToken parameter out of order issue

### DIFF
--- a/src/modules/UI/Wallets/action.js
+++ b/src/modules/UI/Wallets/action.js
@@ -191,7 +191,7 @@ export const editCustomToken = (walletId: string, currencyName: string, currency
     const guiWallet = UI_SELECTORS.getWallet(state, walletId)
     const allTokens = UTILS.mergeTokens(guiWallet.metaTokens, customTokens)
     const indexInAllTokens = _.findIndex(allTokens, (token) => token.currencyCode === currencyCode)
-    const tokenObj = assembleCustomToken(currencyName, currencyCode, denomination, contractAddress)
+    const tokenObj = assembleCustomToken(currencyName, currencyCode, contractAddress, denomination)
     if (indexInAllTokens >= 0) { // currently exists in some form
       if (currencyCode === oldCurrencyCode) { // just updating same token, CASE 1
         addTokenAsync(walletId, currencyName, currencyCode, contractAddress, denomination, state)


### PR DESCRIPTION
The purpose of this is to fix issue related to EditToken. It looks like the function for editing a token included parameters that were out of order (contractAddress and denomination). This should fix the issue.

Asana Task: https://app.asana.com/0/361770107085503/544304196013553/f