### PR TITLE
Fix: show token code in exchange scene drop down header

### DIFF
--- a/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
+++ b/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
@@ -78,9 +78,10 @@ export class CryptoExchangeFlipInputWrapperComponent extends Component<Props, St
             </View>
         </View>
     }
-    const {guiWallet: {name: guiWalletName, currencyCode}} = this.props
+    const {guiWallet: {name: guiWalletName},
+      primaryCurrencyInfo: {displayDenomination: { name: displayDenomination }}} = this.props
     const titleComp = function (styles) {
-      return (<WalletNameHeader name={guiWalletName} selectedWalletCurrencyCode={currencyCode} styles={styles}/>)
+      return (<WalletNameHeader name={guiWalletName} denomination={displayDenomination} styles={styles}/>)
     }
 
     return (

--- a/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
+++ b/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
@@ -78,8 +78,8 @@ export class CryptoExchangeFlipInputWrapperComponent extends Component<Props, St
             </View>
         </View>
     }
-    const {guiWallet: {name: guiWalletName},
-      primaryCurrencyInfo: {displayDenomination: { name: displayDenomination }}} = this.props
+    const guiWalletName = this.props.guiWallet.name
+    const displayDenomination = this.props.primaryCurrencyInfo.displayDenomination.name
     const titleComp = function (styles) {
       return (<WalletNameHeader name={guiWalletName} denomination={displayDenomination} styles={styles}/>)
     }

--- a/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
+++ b/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
@@ -9,7 +9,7 @@ type Props = {
     textStyles: Array<{}>
   },
   name: string,
-  selectedWalletCurrencyCode: string
+  denomination: string
 }
 
 class WalletNameHeader extends React.Component<Props> {
@@ -17,7 +17,7 @@ class WalletNameHeader extends React.Component<Props> {
     const {styles = {}} = this.props
     const textStyles = styles.textStyles || []
     const name = this.props.name
-    const selectedWalletCurrencyCode = this.props.selectedWalletCurrencyCode
+    const denomination = this.props.denomination
 
     return (
       <View style={style.headerNameContainer}>
@@ -28,7 +28,7 @@ class WalletNameHeader extends React.Component<Props> {
         >
           {name}:
           <Text style={[style.cCode, ...textStyles]}>
-            {selectedWalletCurrencyCode}
+            {denomination}
           </Text>
         </Text>
       </View>

--- a/src/modules/UI/components/Header/Component/WalletSelectorConnector.js
+++ b/src/modules/UI/components/Header/Component/WalletSelectorConnector.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state: State): StateProps => {
   const selectedWalletCurrencyCode = UI_SELECTORS.getSelectedCurrencyCode(state)
   const title = selectedWallet
     ? function HeaderComp (styles) {
-      return (<WalletNameHeader name={selectedWallet.name} selectedWalletCurrencyCode={selectedWalletCurrencyCode} styles={styles}/>)
+      return (<WalletNameHeader name={selectedWallet.name} denomination={selectedWalletCurrencyCode} styles={styles}/>)
     }
   : s.strings.loading
   return { title }


### PR DESCRIPTION
Exchange scene drop down header doesn’t show token codes (https://app.asana.com/0/361770107085503/498144750192718/f)