### PR TITLE
Reset state of modal when submitting password for confirmation

### DIFF
--- a/src/modules/UI/scenes/Settings/components/ConfirmPasswordModal.ui.js
+++ b/src/modules/UI/scenes/Settings/components/ConfirmPasswordModal.ui.js
@@ -23,11 +23,18 @@ type ConfirmPasswordModalProps = {
 type State = {
   confimPassword: string
 }
-export default class CryptoExchangeConfirmTransactionModal extends Component<ConfirmPasswordModalProps, State> {
+export default class ConfirmPasswordModal extends Component<ConfirmPasswordModalProps, State> {
   componentWillMount () {
     this.setState({
       confimPassword: ''
     })
+  }
+  componentWillReceiveProps (nextProps: ConfirmPasswordModalProps) {
+    if (nextProps.showModal) {
+      this.setState({
+        confimPassword: ''
+      })
+    }
   }
   textChange = (value: string) => {
     this.setState({


### PR DESCRIPTION
Password was never stored in Redux, however the design of our modals allowed it to stay in local state even after the modal was closed. This fixes that. 