### PR TITLE
Slight adjustments to layout on CreateWallet scenes to utilize space

### DIFF
--- a/src/modules/UI/scenes/CreateWallet/CreateWalletSelectCrypto.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletSelectCrypto.ui.js
@@ -108,7 +108,7 @@ export class CreateWalletSelectCrypto extends Component<CreateWalletSelectCrypto
               (entry.currencyCode.toLowerCase().indexOf(this.state.searchTerm.toLowerCase()) >= 0))
     })
     const keyboardHeight = this.props.dimensions.keyboardHeight || 0
-    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 50 // substract button area height and FormField height
+    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 36 // substract button area height and FormField height
     return (
       <SafeAreaView>
         <View style={styles.scene}>

--- a/src/modules/UI/scenes/CreateWallet/CreateWalletSelectFiat.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletSelectFiat.ui.js
@@ -102,7 +102,7 @@ export class CreateWalletSelectFiat extends Component<CreateWalletSelectFiatProp
       return (entry.label.toLowerCase().indexOf(this.state.searchTerm.toLowerCase()) >= 0)
     })
     const keyboardHeight = this.props.dimensions.keyboardHeight || 0
-    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 50 // substract button area height and FormField height
+    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 36 // substract button area height and FormField height
     return (
       <SafeAreaView>
         <View style={styles.scene}>

--- a/src/modules/UI/scenes/CreateWallet/style.js
+++ b/src/modules/UI/scenes/CreateWallet/style.js
@@ -17,7 +17,7 @@ export const styles = {
   },
   view: {
     position: 'relative',
-    top: 66,
+    top: THEME.HEADER,
     paddingHorizontal: 20,
     paddingVertical: 5
   },


### PR DESCRIPTION
I made slight adjustments to the spacing for search results in the CreateWallet process in order to utilize space more efficiently.

Asana Task: none