### PR TITLE
Fix app freeze after doing sendLogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "buffer": "^5.0.8",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
-    "core-js": "^2.5.3",
+    "core-js": "2.5.2",
     "currency-symbol-map": "^4.0.1",
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",


### PR DESCRIPTION
Asana task: https://app.asana.com/0/361770107085503/520381260581210/f

I found that 
https://github.com/Airbitz/edge-react-gui/blob/c348927410c67b74832c69a35ce3530fd3628998/src/modules/Logs/action.js#L30
throws error on real device (Nexus 5) when "Remote JS debug" is disabled. With enabled debugging everything is working.  I assume it's related to https://github.com/zloirock/core-js/issues/368 . 

I would set `core-js` version strictly to `2.5.2` until it will be fixed on parent module.