### PR TITLE
Choose fromWallet vs selectedWallet based on Custom Fees scene

### DIFF
--- a/src/connectors/components/HeaderMenuExchangeConnector.js
+++ b/src/connectors/components/HeaderMenuExchangeConnector.js
@@ -9,8 +9,9 @@ import * as Constants from '../../constants/indexConstants'
 import s from '../../locales/strings.js'
 import THEME from '../../theme/variables/airbitz'
 import {openHelpModal} from '../../modules/UI/components/HelpModal/actions'
+import type {State, Dispatch} from '../../modules/ReduxTypes.js'
 
-export const mapStateToProps = (state: any) => {
+export const mapStateToProps = (state: State) => {
   const data = [
     {
       label: s.strings.title_change_mining_fee, // tie into
@@ -35,7 +36,7 @@ export const mapStateToProps = (state: any) => {
   }
 }
 
-export const mapDispatchToProps = (dispatch: any) => ({
+export const mapDispatchToProps = (dispatch: Dispatch) => ({
   onSelect: (value: string) => {
     switch (value) {
       case Constants.HELP_VALUE:

--- a/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFeesModalConnector.js
+++ b/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFeesModalConnector.js
@@ -16,8 +16,8 @@ import * as UI_SELECTORS from '../../../../selectors.js'
 import { updateMiningFees } from '../../../SendConfirmation/action'
 
 const mapStateToProps = (state: State) => {
-  const selectedWalletId = UI_SELECTORS.getSelectedWalletId(state)
-  const wallet = CORE_SELECTORS.getWallet(state, selectedWalletId)
+  const sourceWalletId: string = UI_SELECTORS.getFromWalletId(state, Actions.currentScene)
+  const wallet = CORE_SELECTORS.getWallet(state, sourceWalletId)
   let customFeeSettings = []
   if (_.has(wallet, 'currencyInfo.defaultSettings.customFeeSettings')) {
     customFeeSettings = wallet.currencyInfo.defaultSettings.customFeeSettings

--- a/src/modules/UI/selectors.js
+++ b/src/modules/UI/selectors.js
@@ -6,6 +6,10 @@ import _ from 'lodash'
 import type {State} from '../ReduxTypes'
 import type {GuiDenomination, GuiWallet} from '../../types'
 import * as SETTINGS_SELECTORS from './Settings/selectors'
+import {
+  CHANGE_MINING_FEE_EXCHANGE,
+  CHANGE_MINING_FEE_SEND_CONFIRMATION
+} from '../../constants/SceneKeys.js'
 
 export const getWallets = (state: State) => { // returns an object with GUI Wallets as Keys Not sure how to tpye that
   const wallets = state.ui.wallets.byId
@@ -21,6 +25,21 @@ export const getWallet = (state: State, walletId: string) => {
 export const getSelectedWalletId = (state: State): string => {
   const selectedWalletId = state.ui.wallets.selectedWalletId
   return selectedWalletId
+}
+
+export const getFromWalletId = (state: State, sceneKey: string): string => {
+  let id = ''
+  switch (sceneKey) {
+    case CHANGE_MINING_FEE_EXCHANGE :
+      if (state.cryptoExchange.fromWallet) {
+        id = state.cryptoExchange.fromWallet.id
+      }
+      break
+    case CHANGE_MINING_FEE_SEND_CONFIRMATION :
+      id = state.ui.wallets.selectedWalletId
+      break
+  }
+  return id
 }
 
 export const getSelectedCurrencyCode = (state: State): string => {


### PR DESCRIPTION
The purpose of this task is to base the custom mining fee *type* based on which scene it is coming from, since the exchange scene and sendConfirmation scenes both have source wallets. It will now look at `selectedWallet` from SendConfirmation scene and `fromWallet` for the cryptoExchange scene.

Asana Task: https://app.asana.com/0/361770107085503/498144750192722/f