### PR TITLE
Center exchangeModal slider and reduce width

### DIFF
--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeConfirmTransactionModalComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeConfirmTransactionModalComponent.js
@@ -98,19 +98,20 @@ export default class CryptoExchangeConfirmTransactionModal extends Component<Cry
         <View style={shim} />
         <View style={shim} />
       </View>
-
       <Slider onSlidingComplete={this.props.confirmFunction} sliderDisabled={false}
         parentStyle={{
           backgroundColor: THEME.COLORS.SECONDARY,
           borderRadius: 40,
           marginBottom: 10,
           marginLeft: 0,
-          marginRight: 0
+          marginRight: 0,
+          width: 270,
+          alignSelf: 'center'
         }} />
     </View>
   }
 
   renderBottom = (style: Object) => {
-    return <TouchableOpacity><Text style={style.bottomButton} onPress={this.props.closeFunction}>Cancel</Text></TouchableOpacity>
+    return <TouchableOpacity><Text style={style.bottomButton} onPress={this.props.closeFunction}>{s.strings.string_cancel_cap}</Text></TouchableOpacity>
   }
 }


### PR DESCRIPTION
The purpose of this task is to make the Exchange scene's confirmation slider a more appropriate width on tablets. I mimicked the width style that is used for the sendConfirmation scene.

Asana Task: https://app.asana.com/0/361770107085503/545202805762048/f