### PR TITLE
Implement different version of passing sourceWallet to changeMiningFee

### DIFF
--- a/src/connectors/components/HeaderMenuExchangeConnector.js
+++ b/src/connectors/components/HeaderMenuExchangeConnector.js
@@ -9,20 +9,40 @@ import * as Constants from '../../constants/indexConstants'
 import s from '../../locales/strings.js'
 import THEME from '../../theme/variables/airbitz'
 import {openHelpModal} from '../../modules/UI/components/HelpModal/actions'
+import * as CORE_SELECTORS from '../../modules/Core/selectors.js'
 
 export const mapStateToProps = (state: any) => {
+  let sourceWalletId, sourceWallet
+  if (state.cryptoExchange && state.cryptoExchange.fromWallet) {
+    sourceWalletId = state.cryptoExchange.fromWallet.id
+    sourceWallet = CORE_SELECTORS.getWallet(state, sourceWalletId)
+  } else {
+    sourceWalletId = ''
+    sourceWallet = null
+  }
+
   const data = [
     {
-      label: s.strings.title_change_mining_fee, // tie into
-      value: Constants.CHANGE_MINING_FEE_VALUE
+      label: s.strings.title_change_mining_fee, // tie into,
+      key: s.strings.title_change_mining_fee,
+      value: {
+        title: Constants.CHANGE_MINING_FEE_VALUE,
+        sourceWallet
+      }
     },
     {
       label: s.strings.dropdown_exchange_max_amount,
-      value: Constants.EXCHANGE_MAX_AMOUNT_VALUE
+      key: s.strings.dropdown_exchange_max_amount,
+      value: {
+        title: Constants.EXCHANGE_MAX_AMOUNT_VALUE
+      }
     },
     {
       label: s.strings.string_help,
-      value: Constants.HELP_VALUE
+      key: s.strings.string_help,
+      value: {
+        title: Constants.HELP_VALUE
+      }
     }
   ]
   return {
@@ -31,13 +51,14 @@ export const mapStateToProps = (state: any) => {
     },
     exchangeRate: state.cryptoExchange.exchangeRate,
     data,
-    rightSide: true
+    rightSide: true,
+    sourceWallet
   }
 }
 
 export const mapDispatchToProps = (dispatch: any) => ({
-  onSelect: (value: string) => {
-    switch (value) {
+  onSelect: (value: Object) => {
+    switch (value.title) {
       case Constants.HELP_VALUE:
         dispatch(openHelpModal())
         break
@@ -45,7 +66,7 @@ export const mapDispatchToProps = (dispatch: any) => ({
         dispatch(actions.exchangeMax())
         break
       case Constants.CHANGE_MINING_FEE_VALUE:
-        Actions[Constants.CHANGE_MINING_FEE_EXCHANGE]()
+        Actions[Constants.CHANGE_MINING_FEE_EXCHANGE]({sourceWallet: value.sourceWallet})
         break
     }
   }

--- a/src/modules/UI/components/MenuDropDown/MenuDropDown.ui.js
+++ b/src/modules/UI/components/MenuDropDown/MenuDropDown.ui.js
@@ -23,7 +23,7 @@ export default class MenuDropDown extends Component<Props> {
       <MenuOption
         style={style.menuOption}
         value={item.value}
-        key={'ld' + item.value}
+        key={'ld' + (item.key || item.value)}
       >
         <View style={[style.menuOptionItem]}>
           <Text style={[style.optionText]}>

--- a/src/modules/UI/scenes/ChangeMiningFee/ChangeMiningFee.ui.js
+++ b/src/modules/UI/scenes/ChangeMiningFee/ChangeMiningFee.ui.js
@@ -10,6 +10,7 @@ import CustomFees from './components/CustomFees/CustomFeesConnector.js'
 
 import * as FEE from '../../../../constants/FeeConstants'
 import s from '../../../../locales/strings.js'
+import type {EdgeCurrencyWallet} from 'edge-login'
 
 import styles from './style'
 
@@ -20,7 +21,8 @@ const LOW_FEE_TEXT = s.strings.mining_fee_low_label_choice
 export type ChangeMiningFeeOwnProps = {
   // fee: string,
   feeSetting: string,
-  onSubmit: (feeSetting: string) => Promise<void>
+  onSubmit: (feeSetting: string) => Promise<void>,
+  sourceWallet: EdgeCurrencyWallet
 }
 
 export type ChangeMiningFeeStateProps = {
@@ -88,7 +90,7 @@ export default class ChangeMiningFee extends Component<ChangeMiningFeeProps, Sta
                 isSelected={FEE.LOW_FEE === feeSetting}
               />
             </View>
-            <CustomFees handlePress={this.handlePress}/>
+            <CustomFees handlePress={this.handlePress} sourceWallet={this.props.sourceWallet} />
           </View>
         </View>
       </SafeAreaView>

--- a/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFees.ui.js
+++ b/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFees.ui.js
@@ -6,12 +6,14 @@ import { View } from 'react-native'
 import CustomFeesModal from './CustomFeesModalConnector.js'
 import { PrimaryButton } from '../../../../components/Buttons/Buttons.ui'
 import s from '../../../../../../locales/strings.js'
+import type {EdgeCurrencyWallet} from 'edge-login'
 
 import styles from './style'
 
 type Props = {
   onPressed: Function,
-  handlePress: Function
+  handlePress: Function,
+  sourceWallet: EdgeCurrencyWallet
 }
 type State = {}
 
@@ -24,7 +26,7 @@ export default class CustomFees extends Component<Props, State> {
           style={styles.customFeeButton}
           onPressFunction={this.props.onPressed}
         />
-        <CustomFeesModal handlePress={this.props.handlePress}/>
+        <CustomFeesModal handlePress={this.props.handlePress} sourceWallet={this.props.sourceWallet} />
       </View>
     )
   }

--- a/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFeesModal.ui.js
+++ b/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFeesModal.ui.js
@@ -9,23 +9,25 @@ import styles from './style'
 import OptionIcon from '../../../../components/OptionIcon/OptionIcon.ui'
 import OptionButtons from '../../../../components/OptionButtons/OptionButtons.ui.js'
 import s from '../../../../../../locales/strings.js'
+import type {EdgeCurrencyWallet} from 'edge-login'
 
 export type CustomFees = {
   [feeSetting: string]: string
 }
 
-export type Props = {
+export type CustomFeesModalOwnProps = {
   customFeeSettings: Array<string>,
   visibilityBoolean: boolean,
   onPositive: (customFees: CustomFees) => void,
   onDone: () => void,
-  handlePress: Function
+  handlePress: Function,
+  sourceWallet: EdgeCurrencyWallet
 }
 
 type State = CustomFees
 
-export default class CustomFeesModal extends Component<Props, State> {
-  constructor (props: Props) {
+export default class CustomFeesModal extends Component<CustomFeesModalOwnProps, State> {
+  constructor (props: CustomFeesModalOwnProps) {
     super(props)
     this.state = {}
   }

--- a/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFeesModalConnector.js
+++ b/src/modules/UI/scenes/ChangeMiningFee/components/CustomFees/CustomFeesModalConnector.js
@@ -4,20 +4,17 @@ import { connect } from 'react-redux'
 import { Actions } from 'react-native-router-flux'
 import _ from 'lodash'
 import CustomFeesModal from './CustomFeesModal.ui'
-import type { CustomFees } from './CustomFeesModal.ui'
+import type { CustomFees, CustomFeesModalOwnProps } from './CustomFeesModal.ui'
 import * as Constants from '../../../../../../constants/indexConstants.js'
 import type { Dispatch, State } from '../../../../../ReduxTypes'
 import {
   CLOSE_MODAL_VALUE
 } from '../../../WalletList/components/WalletOptions/action'
 
-import * as CORE_SELECTORS from '../../../../../Core/selectors.js'
-import * as UI_SELECTORS from '../../../../selectors.js'
 import { updateMiningFees } from '../../../SendConfirmation/action'
 
-const mapStateToProps = (state: State) => {
-  const selectedWalletId = UI_SELECTORS.getSelectedWalletId(state)
-  const wallet = CORE_SELECTORS.getWallet(state, selectedWalletId)
+const mapStateToProps = (state: State, ownProps: CustomFeesModalOwnProps) => {
+  const wallet = ownProps.sourceWallet
   let customFeeSettings = []
   if (_.has(wallet, 'currencyInfo.defaultSettings.customFeeSettings')) {
     customFeeSettings = wallet.currencyInfo.defaultSettings.customFeeSettings

--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmationOptions.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmationOptions.js
@@ -6,6 +6,7 @@ import Menu, {MenuOptions, MenuOption, MenuTrigger} from 'react-native-menu'
 import s from '../../../../locales/strings.js'
 import {border} from '../../../utils'
 import styles from './styles'
+import type {EdgeCurrencyWallet} from 'edge-login'
 
 const CHANGE_MINING_FEE_TEXT = s.strings.title_change_mining_fee
 const CHANGE_CURRENCY_TEXT = s.strings.change_currency_fee
@@ -18,16 +19,17 @@ const SEND_MAX = 'SEND_MAX'
 const HELP = 'HELP'
 
 type Props = {
-  changeMiningFee: () => void,
+  changeMiningFee: (EdgeCurrencyWallet) => void,
   openHelpModal: () => void,
-  sendMaxSpend: () => void
+  sendMaxSpend: () => void,
+  sourceWallet: EdgeCurrencyWallet
 }
 type State = {}
 export default class SendConfirmationOptions extends Component<Props, State> {
   handleMenuOptions (key: string) {
     switch (key) {
       case CHANGE_MINING_FEE:
-        return this.props.changeMiningFee()
+        return this.props.changeMiningFee(this.props.sourceWallet)
       case HELP:
         return this.props.openHelpModal()
       case SEND_MAX:

--- a/src/modules/UI/scenes/SendConfirmation/SendConfirmationOptionsConnector.js
+++ b/src/modules/UI/scenes/SendConfirmation/SendConfirmationOptionsConnector.js
@@ -1,16 +1,25 @@
+// @flow
+
 import { connect } from 'react-redux'
 import { Actions } from 'react-native-router-flux'
 import SendConfirmationOptions from './SendConfirmationOptions'
 
 import { CHANGE_MINING_FEE_SEND_CONFIRMATION } from '../../../../constants/indexConstants'
+import type { State, Dispatch } from '../../../ReduxTypes'
+import * as CORE_SELECTORS from '../../../Core/selectors.js'
 
 import { openHelpModal } from '../../components/HelpModal/actions.js'
 import { updateMaxSpend } from './action'
 
-const mapStateToProps = () => ({})
+const mapStateToProps = (state: State) => {
+  const sourceWalletId = state.ui.wallets.selectedWalletId
+  return ({
+    sourceWallet: CORE_SELECTORS.getWallet(state, sourceWalletId)
+  })
+}
 
-const mapDispatchToProps = (dispatch) => ({
-  changeMiningFee: Actions[CHANGE_MINING_FEE_SEND_CONFIRMATION],
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  changeMiningFee: (sourceWallet) => Actions[CHANGE_MINING_FEE_SEND_CONFIRMATION]({sourceWallet}),
   openHelpModal: () => dispatch(openHelpModal()),
   sendMaxSpend: () => dispatch(updateMaxSpend())
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,6 +2276,31 @@ edge-login@^0.5.0, edge-login@^0.5.3:
     scrypt-js "^2.0.3"
     utf8 "^2.1.2"
 
+edge-login@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/edge-login/-/edge-login-0.5.3.tgz#255944fade2f197119f26be25eb234bf12c71aff"
+  dependencies:
+    aes-js "^3.1.0"
+    base-x "^1.0.4"
+    biggystring "^1.0.7"
+    chai "^4.1.2"
+    currency-codes "^1.1.2"
+    detect-bundler "^1.0.0"
+    disklet "^0.2.2"
+    elliptic "^6.4.0"
+    hash.js "^1.0.3"
+    hmac-drbg "^1.0.1"
+    mocha "^3.5.0"
+    node-fetch "^1.7.3"
+    redux "^3.6.0"
+    redux-keto "^0.3.2"
+    redux-pixies "^0.3.3"
+    redux-thunk "^2.2.0"
+    regenerator-runtime "^0.11.1"
+    rfc4648 "^1.0.0"
+    scrypt-js "^2.0.3"
+    utf8 "^2.1.2"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
The purpose of this task is to base the custom mining fee type based on which scene it is coming from, since the exchange scene and sendConfirmation scenes both have source wallets. It will now look at selectedWallet from SendConfirmation scene and fromWallet for the cryptoExchange scene.

Asana Task: https://app.asana.com/0/361770107085503/498144750192722/f