### PR TITLE
Fix Android flushing icons on loading wallets

### DIFF
--- a/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
+++ b/src/modules/UI/scenes/WalletList/components/WalletListRow/FullWalletListRow.ui.js
@@ -146,7 +146,10 @@ class FullWalletListRow extends Component<Props, State> {
                   (
                     <View style={[styles.rowNameTextWrapAndroid, b()]}>
                     {symbolImageDarkMono &&
-                      <Image style={[styles.rowCurrencyLogoAndroid, b()]} source={{uri: symbolImageDarkMono}} />
+                      <Image
+                        style={[styles.rowCurrencyLogoAndroid, b()]}
+                        source={{uri: symbolImageDarkMono}}
+                        resizeMode='cover' />
                     }
                     <T style={[styles.rowNameText, b()]} numberOfLines={1}>
                       {cutOffText(name, 34)}</T>


### PR DESCRIPTION
Asana task: https://app.asana.com/0/361770107085503/530358262723340/f