### PR TITLE
Add visual feedback for when new transactions are being attempted.

### DIFF
--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
@@ -210,6 +210,9 @@ export class CryptoExchangeSceneComponent extends Component<Props, State> {
         processingFlag={this.props.gettingTransaction}
         processingElement={<ActivityIndicator />} />
     }
+    if (this.props.gettingTransaction) {
+      return <ActivityIndicator />
+    }
     return null
   }
   flipThis = () => {

--- a/src/reducers/CryptoExchangeReducer.js
+++ b/src/reducers/CryptoExchangeReducer.js
@@ -168,7 +168,11 @@ function cryptoExchangerReducer (state = initialState, action) {
         forceUpdateGuiCounter: (state.forceUpdateGuiCounter + 1)
       }
     case Constants.START_MAKE_SPEND:
-      return { ...state, gettingTransaction: true }
+      return { ...state,
+        gettingTransaction: true,
+        insufficientError: false,
+        genericShapeShiftError: null
+      }
     case Constants.DONE_MAKE_SPEND:
       return { ...state, gettingTransaction: false }
     default:


### PR DESCRIPTION
This resets the error messages in between each make spend, and makes sure there is a spinner showing while the app is thinking, and attempting a make spend. It provides necessary visual feedback and will not allow errors to remain 