### PR TITLE
Change string for custom gasPrice to be "Gas Price (GWei)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-react-gui",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "description": "Edge Wallet React GUI",
   "homepage": "https://edgesecure.co",
@@ -77,7 +77,7 @@
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
     "edge-currency-bitcoin": "2.14.4",
-    "edge-currency-ethereum": "0.7.12",
+    "edge-currency-ethereum": "0.8.0",
     "edge-exchange-plugins": "^0.1.1",
     "edge-login": "^0.5.5",
     "https-browserify": "0.0.1",

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -145,7 +145,7 @@ const strings = {
   string_custom_fee: 'Set Fees',
   satPerByte: 'Satoshi Per Byte',
   gasLimit: 'Gas Limit',
-  gasPrice: 'Gas Price',
+  gasPrice: 'Gas Price (Gwei)',
   string_disable: 'DISABLE',
   string_done_cap: 'Done',
   string_fee_with_colon: 'Fee: ',


### PR DESCRIPTION
Requires update to 0.8.0 of ethereum library which actually uses GWei as the gasPrice parameter

PR https://github.com/Airbitz/edge-currency-ethereum/pull/7 should first be reviewed, merged, and npm published before this PR is accepted. Otherwise we will get a build error due to missing npm version 0.8.0 of the ethereum library