### PR TITLE
Remove unnecessary text in Exchange scene dropdown headers

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -19,8 +19,6 @@ const strings = {
   edge_description: 'This application would like to create or access its wallet in your Edge account.\n\n It will not have access to any other wallets.',
   exchange_failed: 'Exchange Failed',
   exchange_succeeded: 'Exchange Succeeded',
-  fragment_exchange_from: 'From:',
-  fragment_exchange_to: 'To:',
   exchanges_may_take_minutes: 'Exchanges may take several minutes to process. Please check your destination wallet after a few minutes',
   fragment_wallets_addwallet_blockchain_hint: 'Choose a blockchain',
   fragment_wallets_addwallet_fiat_hint: 'Choose a fiat currency',

--- a/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
+++ b/src/modules/UI/components/FlipInput/CryptoExchangeFlipInputWrapperComponent.js
@@ -12,7 +12,6 @@ import type { ExchangedFlipInputAmounts } from './ExchangedFlipInput2.js'
 type State = {}
 
 export type Props = {
-  walletDirectionString: string,
   style: StyleSheet.Styles,
   guiWallet: GuiWallet,
   fee: string | null,
@@ -64,7 +63,7 @@ export class CryptoExchangeFlipInputWrapperComponent extends Component<Props, St
 
   render () {
     const style: StyleSheet.Styles = this.props.style
-    const { primaryCurrencyInfo, secondaryCurrencyInfo, fiatPerCrypto, forceUpdateGuiCounter, overridePrimaryExchangeAmount, walletDirectionString } = this.props
+    const { primaryCurrencyInfo, secondaryCurrencyInfo, fiatPerCrypto, forceUpdateGuiCounter, overridePrimaryExchangeAmount } = this.props
 
     if (!this.props.guiWallet || this.props.guiWallet.id === '' || !primaryCurrencyInfo || !secondaryCurrencyInfo) {
       return (
@@ -83,7 +82,7 @@ export class CryptoExchangeFlipInputWrapperComponent extends Component<Props, St
     const guiWalletName = this.props.guiWallet.name
     const displayDenomination = this.props.primaryCurrencyInfo.displayCurrencyCode
     const titleComp = function (styles) {
-      return <WalletNameHeader walletDirectionString={walletDirectionString} name={guiWalletName} denomination={displayDenomination} styles={styles} />
+      return <WalletNameHeader name={guiWalletName} denomination={displayDenomination} styles={styles} />
     }
 
     return (

--- a/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
+++ b/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
@@ -8,8 +8,7 @@ type Props = {
   styles: {
     textStyles: Array<{}>
   },
-  name: string,
-  denomination: string
+  name: string
 }
 
 class WalletNameHeader extends React.Component<Props> {
@@ -17,13 +16,11 @@ class WalletNameHeader extends React.Component<Props> {
     const { styles = {} } = this.props
     const textStyles = styles.textStyles || []
     const name = this.props.name
-    const denomination = this.props.denomination
 
     return (
       <View style={style.headerNameContainer}>
         <Text style={textStyles} ellipsizeMode={'middle'} numberOfLines={1}>
-          {name}:
-          <Text style={[style.cCode, ...textStyles]}>{denomination}</Text>
+          {name}
         </Text>
       </View>
     )

--- a/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
+++ b/src/modules/UI/components/Header/Component/WalletNameHeader.ui.js
@@ -9,8 +9,7 @@ type Props = {
     textStyles: Array<{}>
   },
   name: string,
-  denomination: string,
-  walletDirectionString?: string
+  denomination: string
 }
 
 class WalletNameHeader extends React.Component<Props> {
@@ -19,13 +18,12 @@ class WalletNameHeader extends React.Component<Props> {
     const textStyles = styles.textStyles || []
     const name = this.props.name
     const denomination = this.props.denomination
-    const directionPrefix = this.props.walletDirectionString ? this.props.walletDirectionString : ''
 
     return (
       <View style={style.headerNameContainer}>
         <Text style={textStyles} ellipsizeMode={'middle'} numberOfLines={1}>
-          {directionPrefix + ' ' + name}
-          <Text style={[style.cCode, ...textStyles]}> ({denomination})</Text>
+          {name}:
+          <Text style={[style.cCode, ...textStyles]}>{denomination}</Text>
         </Text>
       </View>
     )

--- a/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
+++ b/src/modules/UI/scenes/CryptoExchange/CryptoExchangeSceneComponent.js
@@ -152,7 +152,6 @@ export class CryptoExchangeSceneComponent extends Component<Props, State> {
             <CryptoExchangeConnector style={style.exchangeRateBanner} />
             <View style={style.shim} />
             <CryptoExchangeFlipInputWrapperComponent
-              walletDirectionString={s.strings.fragment_exchange_from}
               style={style.flipWrapper}
               guiWallet={this.props.fromWallet}
               fee={this.props.fee}
@@ -171,7 +170,6 @@ export class CryptoExchangeSceneComponent extends Component<Props, State> {
             <View style={style.shim} />
             <CryptoExchangeFlipInputWrapperComponent
               style={style.flipWrapper}
-              walletDirectionString={s.strings.fragment_exchange_to}
               guiWallet={this.props.toWallet}
               fee={null}
               buttonText={this.props.toButtonText}


### PR DESCRIPTION
This is a slight reversion of a previous commit, because the designs I was looking at were old and some parts are redundant (ie the crypto type in the header, since there is already a denomination, crypto logo, and crypto code in the box).

Asana Task: https://app.asana.com/0/361770107085503/475629743533054/f