### PR TITLE
update edge-core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "currency-symbol-map": "^4.0.1",
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
-    "edge-core-js": "^0.6.3",
+    "edge-core-js": "git://github.com/Airbitz/edge-core-js.git#develop",
     "edge-currency-bitcoin": "2.14.9",
     "edge-currency-ethereum": "0.8.1",
     "edge-exchange-plugins": "^0.1.1",

--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -26,7 +26,7 @@ import SafeAreaView from '../../components/SafeAreaView'
 import styles, { styles as styleRaw } from './style'
 
 // import SearchBar from './components/SearchBar.ui'
-const INITIAL_TRANSACTION_BATCH_NUMBER = 1
+const INITIAL_TRANSACTION_BATCH_NUMBER = 10
 const SUBSEQUENT_TRANSACTION_BATCH_NUMBER = 30
 const SCROLL_THRESHOLD = 0.5
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,9 +2202,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-edge-core-js@^0.6.3:
+"edge-core-js@git://github.com/Airbitz/edge-core-js.git#develop":
   version "0.6.3"
-  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.6.3.tgz#d2657afeb86cf2f1e000822f272e07e8b79dd5f0"
+  resolved "git://github.com/Airbitz/edge-core-js.git#90886518eac09011a90a2aed52e3e2b9793e7eb0"
   dependencies:
     aes-js "^3.1.0"
     base-x "^1.0.4"


### PR DESCRIPTION
Performance optimizations including:
1. "getTransactions" can now  slice and return only a portion of the transaction list which is kept sorted even without decrypting the transaction files (which took forever).
2. "onTransactionChanged" is a lot more picky an won't fire on every login but will only happen when either the blockchain data has changed (like a tx that got confirmed) or the metadata has changed.
Even new installation won't call this callback if the tx hasn't changed since the last time the app was open on any other installation.
3. Create a mapping file from the old legacy format to the new one so that we will only need to decrypt the legacy files once per file.