### PR TITLE
Fix failed refresh of txlist after editing tx details

### DIFF
--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -141,6 +141,7 @@ type Props = {
   dispatchEnableScan: () => void,
   dispatchDisableScan: () => void,
   urlReceived: string => void,
+  updateCurrentSceneKey: (string) => void,
   contextCallbacks: AbcContextCallbacks
 }
 type State = {
@@ -293,7 +294,10 @@ export default class Main extends Component<Props, State> {
 
                         <Scene
                           key={Constants.TRANSACTION_LIST}
-                          onEnter={() => this.props.requestPermission(CONTACTS)}
+                          onEnter={() => {
+                            this.props.requestPermission(CONTACTS)
+                            this.props.updateCurrentSceneKey(Constants.TRANSACTION_LIST)
+                          }}
                           navTransparent={true}
                           component={TransactionListConnector}
                           renderTitle={this.renderWalletListNavBar()}

--- a/src/modules/MainConnector.js
+++ b/src/modules/MainConnector.js
@@ -11,6 +11,7 @@ import type { Dispatch } from './ReduxTypes'
 import { setKeyboardHeight } from './UI/dimensions/action'
 import { disableScan, enableScan } from './UI/scenes/Scan/action'
 import { addCurrencyPlugin } from './UI/Settings/action'
+import { updateCurrentSceneKey } from './UI/scenes/action.js'
 
 const mapStateToProps = () => ({})
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -34,6 +35,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   },
   addUsernames: usernames => {
     return dispatch(addUsernames(usernames))
+  },
+  updateCurrentSceneKey: (sceneKey) => {
+    return dispatch(updateCurrentSceneKey(sceneKey))
   },
   // commented out since it was blowing up flow && doesnt seem to be called.. TODO remove
   /* setLocaleInfo: (localeInfo) => {


### PR DESCRIPTION
updateCurrentSceneKey was incorrectly removed for TX_LIST so we were not marking the current scene when entering tx details. onTransactionsChanged -> refreshTransactionsRequest() was only enacting a change of the txlist if we were currently on the tx_list scene.