### PR TITLE
MacOS - Add Requirement to upgrade Xcode where version < 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Edge Wallet is:
 
     https://nodejs.org/en/download/
 
+### (MacOS users) update Xcode (requires Xcode >= 9)
+
+    softwareupdate --install xcode
+    
 ### Install React Native CLI
 
     npm install -g react-native-cli

--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ Edge Wallet is:
 
 ---
 
+## Requirements
+
+  ### MacOS
+   
+   Xcode >= 9
+
 ## Getting Started
 
 ### Install nodejs (v 8.4+) and npm (v 5.3+)
 
     https://nodejs.org/en/download/
-
-### (MacOS users) update Xcode (requires Xcode >= 9)
-
-    softwareupdate --install xcode
     
 ### Install React Native CLI
 


### PR DESCRIPTION
Where Xcode version is < 9, running `react-native run-ios` fails with the following:
```
ld: framework not found FileProvider for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Upgrading fixes this issue.
Add a requirement in the README to upgrade Xcode.