### PR TITLE
Change txList balance box styling to prevent icon cutoff

### DIFF
--- a/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
+++ b/src/modules/UI/scenes/TransactionList/TransactionList.ui.js
@@ -15,7 +15,6 @@ import sendImage from '../../../../assets/images/transactions/transactions-send.
 import * as Constants from '../../../../constants/indexConstants'
 import { intl } from '../../../../locales/intl'
 import s from '../../../../locales/strings.js'
-import { PLATFORM } from '../../../../theme/variables/platform.js'
 
 import type { GuiWallet, DateTransactionGroup, TransactionListTx, TransactionListSection, GuiContact } from '../../../../types'
 import WalletListModal from '../../../UI/components/WalletListModal/WalletListModalConnector'
@@ -258,14 +257,14 @@ export default class TransactionList extends Component<Props, State> {
 
     return (
       <SafeAreaView>
-        <View style={[{ width: '100%', height: PLATFORM.usableHeight + PLATFORM.toolbarHeight }, UTILS.border()]}>
+        <View style={[styles.scene]}>
           <Gradient style={styles.gradient} />
-          <ScrollView style={[UTILS.border(), styles.scrollView]}>
-            <View style={[styles.container, UTILS.border()]}>
-              <Animated.View style={[{ height: this.state.balanceBoxHeight }, UTILS.border()]}>
-                <Gradient style={[styles.currentBalanceBox, UTILS.border()]}>
+          <ScrollView style={[styles.scrollView]}>
+            <View style={[styles.container]}>
+              <Animated.View style={[{ height: this.state.balanceBoxHeight }]}>
+                <Gradient style={[styles.currentBalanceBox]}>
                   {this.state.balanceBoxVisible && (
-                    <Animated.View style={{ flex: 1, paddingTop: 10, paddingBottom: 20, opacity: this.state.balanceBoxOpacity }}>
+                    <Animated.View style={[styles.balanceBox, { opacity: this.state.balanceBoxOpacity }]}>
                       {updatingBalance ? (
                         <View style={[styles.currentBalanceWrap]}>
                           <View style={[styles.updatingBalanceWrap]}>
@@ -273,17 +272,17 @@ export default class TransactionList extends Component<Props, State> {
                           </View>
                         </View>
                       ) : (
-                        <TouchableOpacity onPress={this.toggleShowBalance} style={[styles.currentBalanceWrap, UTILS.border()]}>
+                        <TouchableOpacity onPress={this.toggleShowBalance} style={[styles.currentBalanceWrap]}>
                           {this.state.showBalance ? (
                             <View style={styles.balanceShownContainer}>
-                              <View style={[styles.iconWrap, UTILS.border()]}>
+                              <View style={[styles.iconWrap]}>
                                 {logo ? (
-                                  <Image style={[{ height: 28, width: 28, resizeMode: Image.resizeMode.contain }, UTILS.border()]} source={{ uri: logo }} />
+                                  <Image style={[{ height: 28, width: 28, resizeMode: Image.resizeMode.contain }]} source={{ uri: logo }} />
                                 ) : (
                                   <T style={[styles.request]}>{displayDenomination.symbol}</T>
                                 )}
                               </View>
-                              <View style={[styles.currentBalanceBoxBitsWrap, UTILS.border()]}>
+                              <View style={[styles.currentBalanceBoxBitsWrap]}>
                                 <View style={{ flexDirection: 'row' }}>
                                   {displayDenomination.symbol ? (
                                     <T numberOfLines={1} style={[styles.currentBalanceBoxBits, styles.symbol]}>
@@ -302,20 +301,20 @@ export default class TransactionList extends Component<Props, State> {
                                   )}
                                 </View>
                               </View>
-                              <View style={[styles.currentBalanceBoxDollarsWrap, UTILS.border()]}>
-                                <T numberOfLines={1} style={[styles.currentBalanceBoxDollars, UTILS.border()]}>
+                              <View style={[styles.currentBalanceBoxDollarsWrap]}>
+                                <T numberOfLines={1} style={[styles.currentBalanceBoxDollars]}>
                                   {fiatBalanceString}
                                 </T>
                               </View>
                             </View>
                           ) : (
-                            <View style={[UTILS.border(), styles.balanceHiddenContainer]}>
+                            <View style={[styles.balanceHiddenContainer]}>
                               <T style={[styles.balanceHiddenText]}>{SHOW_BALANCE_TEXT}</T>
                             </View>
                           )}
                         </TouchableOpacity>
                       )}
-                      <View style={[styles.requestSendRow, UTILS.border()]}>
+                      <View style={[styles.requestSendRow]}>
                         <TouchableHighlight style={[styles.requestBox, styles.button]} underlayColor={styleRaw.underlay.color} onPress={Actions.request}>
                           <View style={[styles.requestWrap]}>
                             <Image style={{ width: 25, height: 25 }} source={requestImage} />

--- a/src/modules/UI/scenes/TransactionList/style.js
+++ b/src/modules/UI/scenes/TransactionList/style.js
@@ -3,8 +3,13 @@
 import { StyleSheet } from 'react-native'
 
 import THEME from '../../../../theme/variables/airbitz'
+import { PLATFORM } from '../../../../theme/variables/platform.js'
 
 export const styles = {
+  scene: {
+    width: '100%',
+    height: PLATFORM.usableHeight + PLATFORM.toolbarHeight
+  },
   gradient: {
     height: THEME.HEADER
   },
@@ -13,57 +18,17 @@ export const styles = {
     alignItems: 'stretch'
   },
 
-  // searchbar stuff
-
   scrollView: {
     flex: 1
   },
-  searchContainer: {
-    backgroundColor: THEME.COLORS.PRIMARY,
-    height: 44,
-    paddingTop: 8,
-    paddingBottom: 8,
-    paddingRight: 10,
-    paddingLeft: 10,
-    flexDirection: 'row'
-  },
-  innerSearch: {
-    backgroundColor: THEME.COLORS.WHITE,
-    height: 28,
-    borderRadius: 3,
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingLeft: 8,
-    paddingRight: 8
-  },
-  searchIcon: {
-    color: THEME.COLORS.GRAY_2
-  },
-  searchInput: {
-    height: 18,
-    flex: 1,
-    alignSelf: 'center',
-    textAlign: 'center'
-  },
-  cancelButton: {
-    justifyContent: 'space-around',
-    alignItems: 'center',
-    paddingLeft: 6,
-    paddingRight: 6,
-    height: 28
-  },
-  cancelButtonText: {
-    color: THEME.COLORS.WHITE,
-    backgroundColor: THEME.COLORS.TRANSPARENT
-  },
-
-  // end of searchbar stuff
-
   currentBalanceBox: {
-    flex: 1,
+    height: 208,
     justifyContent: 'center'
+  },
+  balanceBox: {
+    height: 208,
+    paddingTop: 10,
+    paddingBottom: 20
   },
   updatingBalanceWrap: {
     alignItems: 'center',
@@ -77,7 +42,7 @@ export const styles = {
   },
   currentBalanceWrap: {
     // one
-    flex: 3,
+    height: 128,
     alignItems: 'center',
     backgroundColor: THEME.COLORS.TRANSPARENT
   },
@@ -87,13 +52,13 @@ export const styles = {
   },
   iconWrap: {
     // two
-    flex: 3,
+    height: 28,
     justifyContent: 'flex-start',
     backgroundColor: THEME.COLORS.TRANSPARENT
   },
   currentBalanceBoxBitssWrap: {
     // two
-    flex: 4,
+    height: 40,
     justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: THEME.COLORS.TRANSPARENT
@@ -104,7 +69,7 @@ export const styles = {
   },
   currentBalanceBoxDollarsWrap: {
     justifyContent: 'flex-start',
-    flex: 4,
+    height: 24,
     paddingTop: 4
   },
   currentBalanceBoxDollars: {
@@ -295,7 +260,51 @@ export const styles = {
   },
   symbol: {
     fontFamily: THEME.FONTS.SYMBOLS
+  },
+
+  // searchbar stuff
+  searchContainer: {
+    backgroundColor: THEME.COLORS.PRIMARY,
+    height: 44,
+    paddingTop: 8,
+    paddingBottom: 8,
+    paddingRight: 10,
+    paddingLeft: 10,
+    flexDirection: 'row'
+  },
+  innerSearch: {
+    backgroundColor: THEME.COLORS.WHITE,
+    height: 28,
+    borderRadius: 3,
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingLeft: 8,
+    paddingRight: 8
+  },
+  searchIcon: {
+    color: THEME.COLORS.GRAY_2
+  },
+  searchInput: {
+    height: 18,
+    flex: 1,
+    alignSelf: 'center',
+    textAlign: 'center'
+  },
+  cancelButton: {
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    paddingLeft: 6,
+    paddingRight: 6,
+    height: 28
+  },
+  cancelButtonText: {
+    color: THEME.COLORS.WHITE,
+    backgroundColor: THEME.COLORS.TRANSPARENT
   }
+
+  // end of searchbar stuff
 }
 
 export default StyleSheet.create(styles)


### PR DESCRIPTION
The purpose of this task is to migrate the Transaction List balance box (top of scene) away from Flexbox to ensure that there is sufficient space to fit the cryptocurrency logo.

https://app.asana.com/0/361770107085503/532233498493258/f