### PR TITLE
Upgrade android JavascriptCore

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,6 +152,12 @@ if (hasProperty('storeFile')) {
     android.signingConfigs.release.keyPassword   = "password"
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'org.webkit:android-jsc:r216113'
+    }
+}
+
 dependencies {
     compile project(':react-native-mail')
     compile project(':react-native-smart-splash-screen')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "$rootDir/../node_modules/jsc-android/android"
+        }
         google()
     }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "edge-currency-ethereum": "0.8.1",
     "edge-exchange-plugins": "^0.1.1",
     "edge-login-ui-rn": "^0.2.1",
+    "jsc-android": "216113.0.3",
     "https-browserify": "0.0.1",
     "lodash": "^4.17.2",
     "native-base": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-native-drawer": "^2.3.0",
     "react-native-dropdown": "git://github.com/g6ling/react-native-dropdown.git",
     "react-native-dropdownalert": "git://github.com/Airbitz/react-native-dropdownalert.git",
-    "react-native-fast-crypto": "^1.5.4",
+    "react-native-fast-crypto": "^1.5.5",
     "react-native-flip-view": "git://github.com/Airbitz/react-native-flip-view.git",
     "react-native-fs": "^2.9.7",
     "react-native-hockeyapp": "0.5.1",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -6,7 +6,7 @@ rm -rf ./node_modules/bccoin/.babelrc ./node_modules/edge-currency-bitcoin/node_
 rm -rf ./node_modules/lcoin/.babelrc ./node_modules/edge-currency-bitcoin/node_modules/lcoin/.babelrc
 
 # Remove inclusion of c++_shared.so library since we are using jsc-android which already includes it
-sed -e "s/, \'-DANDROID_STL=c++_shared\'//g" ./node_modules/react-native-fast-crypto/android/build.gradle > build.gradle
+sed "s/\,[[:space:]]'-DANDROID_STL=c++_shared'//g" ./node_modules/react-native-fast-crypto/android/build.gradle > build.gradle
 mv build.gradle ./node_modules/react-native-fast-crypto/android/build.gradle
 
 # Disable minification

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -5,6 +5,10 @@ rm -rf ./node_modules/bcoin/.babelrc ./node_modules/edge-currency-bitcoin/node_m
 rm -rf ./node_modules/bccoin/.babelrc ./node_modules/edge-currency-bitcoin/node_modules/bccoin/.babelrc
 rm -rf ./node_modules/lcoin/.babelrc ./node_modules/edge-currency-bitcoin/node_modules/lcoin/.babelrc
 
+# Remove inclusion of c++_shared.so library since we are using jsc-android which already includes it
+sed -e "s/, \'-DANDROID_STL=c++_shared\'//g" ./node_modules/react-native-fast-crypto/android/build.gradle > build.gradle
+mv build.gradle ./node_modules/react-native-fast-crypto/android/build.gradle
+
 # Disable minification
 # Macs don't have `sed -i`, so we use a temporary file for the sed output:
 #sed -e 's/minify:.*,/minify: false,/' ./node_modules/react-native/local-cli/bundle/buildBundle.js > buildBundle.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -6003,9 +6003,9 @@ react-native-easy-grid@0.1.17:
   dependencies:
     lodash "^4.11.1"
 
-react-native-fast-crypto@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/react-native-fast-crypto/-/react-native-fast-crypto-1.5.4.tgz#125a6689e05fd7f4b1d6bb9eb1c8335f4a358067"
+react-native-fast-crypto@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/react-native-fast-crypto/-/react-native-fast-crypto-1.5.5.tgz#300bf9ffea0a7e245f09bb440a230b5c12c0a0b1"
   dependencies:
     buffer "^5.0.8"
     rfc4648 "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4234,6 +4234,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsc-android@216113.0.3:
+  version "216113.0.3"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-216113.0.3.tgz#fd655b06cacb84b57abe281641d44a39ac54480f"
+
 jsdom@^9.12.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"


### PR DESCRIPTION
Update JSC on android using jsc-android npm module
App launch gets about a 15% performance boost as mentioned in the jsc-android README. 
Launching app on Pixel 2, timings go from 3.75 to 3.2 seconds.

This will also enable upgrading to 64 bit once react-native-fast-crypto is upgraded to 64 bit since this version of JSC already includes 64 bit support.