### PR TITLE
Revert deletion of upsertWallet dispatch

### DIFF
--- a/src/modules/UI/Wallets/action.js
+++ b/src/modules/UI/Wallets/action.js
@@ -124,6 +124,12 @@ export const upsertWallet = (wallet: EdgeCurrencyWallet) => (dispatch: Dispatch,
   if (!loginStatus) {
     dispatch({ type: 'LOGGED_OUT' })
   }
+  dispatch({
+    type: UPSERT_WALLET,
+    data: {
+      wallet
+    }
+  })
 }
 
 // adds to core and enables in core

--- a/src/modules/UI/Wallets/action.js
+++ b/src/modules/UI/Wallets/action.js
@@ -193,6 +193,7 @@ export const getEnabledTokens = (walletId: string) => async (dispatch: Dispatch,
     await Promise.all(promiseArray)
     // now reflect that change in Redux's version of the wallet
     dispatch(updateWalletEnabledTokens(walletId, tokensToEnable))
+    dispatch(refreshWallet(walletId))
   } catch (e) {
     dispatch(displayErrorAlert(e.message))
   }


### PR DESCRIPTION
The purpose of this task is to restore the `upsertWallet` dispatch and call it to refresh a wallet once its `enabledTokens` have been loaded into redux. This also fixes the wallet rename not being processed until someone logs out then back in.

Asana Tasks: 
https://app.asana.com/0/361770107085503/615088050020510/f
https://app.asana.com/0/361770107085503/614531362120600/f