### PR TITLE
Check for 'cash' as denom name as well as 'bits'

### DIFF
--- a/src/modules/UI/components/ExchangeRate/ExchangedExchangeRate.ui.js
+++ b/src/modules/UI/components/ExchangeRate/ExchangedExchangeRate.ui.js
@@ -30,7 +30,8 @@ export default class ExchangedExchangeRate extends Component<Props> {
   }
 
   isBits (primaryCurrencyInfo: GuiCurrencyInfo) {
-    return primaryCurrencyInfo.displayDenomination.name === 'bits'
+    return (primaryCurrencyInfo.displayDenomination.name === 'bits' ||
+      primaryCurrencyInfo.displayDenomination.name === 'cash')
   }
 
   render () {


### PR DESCRIPTION
In latest bitcoin plugin, BCH now uses 'cash' to denote the small denom of microbits