### PR TITLE
Fix zCoin currencyCode for viewXPub dropdown

### DIFF
--- a/src/constants/DropDownValueConstants.js
+++ b/src/constants/DropDownValueConstants.js
@@ -43,7 +43,7 @@ export const WALLET_OPTIONS = {
   },
   VIEW_XPUB: {
     value: 'viewXPub',
-    currencyCode: ['BTC', 'BCH', 'DASH', 'FTC', 'ZER', 'LTC'],
+    currencyCode: ['BTC', 'BCH', 'DASH', 'FTC', 'XZC', 'LTC'],
     label: s.strings.fragment_wallets_view_xpub,
     modalVisible: true
   }


### PR DESCRIPTION
The purpose of this task is to get zCoin to show a "View XPub" option for the Wallet List options dropdown. The issue was that the currency code for the cryptocurrency was incorrect.

Asana Task: https://app.asana.com/0/361770107085503/669730821581731/f