### PR TITLE
Upgrade to edge-core-js v0.9.3

### DIFF
--- a/copy-core.sh
+++ b/copy-core.sh
@@ -5,13 +5,21 @@ path=${1:-..}
 
 # Builds and copies the Airbitz core libraries into `node_modules`.
 copy_build () {
+  # Build the library:
   (
     cd $path/$1/
     npm run build
   )
+
+  # Prepare a home in node_modules:
   mkdir -p node_modules/$1
+  rm -r node_modules/$1/lib/
+  rm -r node_modules/$1/src/
+
+  # Copy the library:
   cp $path/$1/package.json node_modules/$1/
   cp -r $path/$1/lib/ node_modules/$1/lib/
+  cp -r $path/$1/src/ node_modules/$1/src/
 }
 
 copy_build edge-core-js

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "core-js": "2.5.2",
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
-    "edge-core-js": "0.9.0-beta.1",
+    "edge-core-js": "0.9.3",
     "edge-currency-bitcoin": "git://github.com/Airbitz/edge-currency-bitcoin.git#f0abf75",
     "edge-currency-ethereum": "0.10.1",
     "edge-currency-monero": "git://github.com/Airbitz/edge-currency-monero.git#a013a71",

--- a/src/modules/Core/Wallets/api.js
+++ b/src/modules/Core/Wallets/api.js
@@ -42,7 +42,7 @@ export const setTransactionDetailsRequest = (wallet: EdgeCurrencyWallet, txid: s
 }
 
 export const getReceiveAddress = (wallet: EdgeCurrencyWallet, currencyCode: string): Promise<EdgeReceiveAddress> => {
-  return wallet.getReceiveAddress ? wallet.getReceiveAddress(currencyCode) : Promise.resolve(dummyEdgeReceiveAddress)
+  return wallet.getReceiveAddress ? wallet.getReceiveAddress({ currencyCode }) : Promise.resolve(dummyEdgeReceiveAddress)
 }
 
 export const makeSpend = (wallet: EdgeCurrencyWallet, spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> => {

--- a/src/modules/Core/selectors.js
+++ b/src/modules/Core/selectors.js
@@ -82,6 +82,6 @@ export const getWalletName = (state: State, walletId: string): string => {
 
 export const getBalanceInCrypto = (state: State, walletId: string, currencyCode: string) => {
   const wallet = getWallet(state, walletId)
-  const balance = wallet.getBalance(currencyCode)
+  const balance = wallet.getBalance({ currencyCode })
   return balance
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,9 +2356,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-edge-core-js@0.9.0-beta.1:
-  version "0.9.0-beta.1"
-  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.9.0-beta.1.tgz#eb7cb91580aeda4e3e71493a81e17edc42149407"
+edge-core-js@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/edge-core-js/-/edge-core-js-0.9.3.tgz#f5890a63dc061090eb291d5d5d76853827dc582a"
   dependencies:
     aes-js "^3.1.0"
     base-x "^1.0.4"


### PR DESCRIPTION
The `wallet.getBalance` change is a little worrying to me - I'm not sure how we *ever* got token balances, since the Ethereum plugin would ignore a string-type `options` parameter.