### PR TITLE
Adjust height of scroll area for SelectFiat and SelectCrypto

### DIFF
--- a/src/modules/UI/scenes/CreateWallet/CreateWalletSelectCrypto.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletSelectCrypto.ui.js
@@ -105,7 +105,7 @@ export class CreateWalletSelectCrypto extends Component<Props, State> {
       )
     })
     const keyboardHeight = this.props.dimensions.keyboardHeight || 0
-    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 36 // substract button area height and FormField height
+    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 58 // substract button area height and FormField height
     return (
       <SafeAreaView>
         <View style={styles.scene}>

--- a/src/modules/UI/scenes/CreateWallet/CreateWalletSelectFiat.ui.js
+++ b/src/modules/UI/scenes/CreateWallet/CreateWalletSelectFiat.ui.js
@@ -96,7 +96,7 @@ export class CreateWalletSelectFiat extends Component<Props, State> {
       return entry.label.toLowerCase().indexOf(this.state.searchTerm.toLowerCase()) >= 0
     })
     const keyboardHeight = this.props.dimensions.keyboardHeight || 0
-    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 36 // substract button area height and FormField height
+    const searchResultsHeight = stylesRaw.usableHeight - keyboardHeight - 58 // substract button area height and FormField height
     return (
       <SafeAreaView>
         <View style={styles.scene}>


### PR DESCRIPTION
Now that the list of currencies is long enough to requires a scroll area, it appears that the height of the scroll area is incorrect and causing the bottom currency to be cut off.

Asana Task: https://app.asana.com/0/361770107085503/708912166573224