### PR TITLE
Implement initial 20 XRP Minimum modal on Request scene

### DIFF
--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -59,7 +59,7 @@ const strings = {
   fragment_request_copy_title: 'Copy',
   fragment_request_subtitle: 'Request',
   fragment_request_address_copied: 'Request address successfully copied to clipboard',
-  request_xrp_minimum_notification_title: 'Minimum XRP Balance Required',
+  request_xrp_minimum_notification_title: 'Minimum XRP Required',
   request_xrp_minimum_notification_body: 'Ripple (XRP) wallets require a 20 XRP minimum balance. You must deposit at least 20 XRP to this address before this wallet will show a balance or transactions. 20 XRP will be unspendable for the lifetime of this wallet address.',
   fragment_send_address_dialog_title: 'Send to Public Address',
   fragment_send_address: 'Address',

--- a/src/locales/en_US.js
+++ b/src/locales/en_US.js
@@ -59,6 +59,8 @@ const strings = {
   fragment_request_copy_title: 'Copy',
   fragment_request_subtitle: 'Request',
   fragment_request_address_copied: 'Request address successfully copied to clipboard',
+  request_xrp_minimum_notification_title: 'Minimum XRP Balance Required',
+  request_xrp_minimum_notification_body: 'Ripple (XRP) wallets require a 20 XRP minimum balance. You must deposit at least 20 XRP to this address before this wallet will show a balance or transactions. 20 XRP will be unspendable for the lifetime of this wallet address.',
   fragment_send_address_dialog_title: 'Send to Public Address',
   fragment_send_address: 'Address',
   fragment_send_flash: 'Flash',

--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -405,6 +405,7 @@ export default class Main extends Component<Props, State> {
                       <Scene
                         key={Constants.REQUEST}
                         navTransparent={true}
+                        onEnter={() => this.props.updateCurrentSceneKey(Constants.REQUEST) }
                         icon={this.icon(Constants.REQUEST)}
                         tabBarLabel={REQUEST}
                         component={Request}

--- a/src/modules/Main.ui.js
+++ b/src/modules/Main.ui.js
@@ -274,6 +274,10 @@ export default class Main extends Component<Props, State> {
     this.doDeepLink(event.url)
   }
 
+  updateSceneKeyRequest = () => {
+    this.props.updateCurrentSceneKey(Constants.REQUEST)
+  }
+
   render () {
     return (
       <MenuProvider style={styles.mainMenuContext}>
@@ -405,7 +409,7 @@ export default class Main extends Component<Props, State> {
                       <Scene
                         key={Constants.REQUEST}
                         navTransparent={true}
-                        onEnter={() => this.props.updateCurrentSceneKey(Constants.REQUEST) }
+                        onEnter={this.updateSceneKeyRequest}
                         icon={this.icon(Constants.REQUEST)}
                         tabBarLabel={REQUEST}
                         component={Request}

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -12,6 +12,7 @@ import * as Constants from '../../../../constants/indexConstants'
 import s from '../../../../locales/strings.js'
 import type { GuiCurrencyInfo, GuiReceiveAddress, GuiWallet } from '../../../../types.js'
 import WalletListModal from '../../../UI/components/WalletListModal/WalletListModalConnector'
+import XRPMinimumModal from './components/XRPMinimumModal/XRPMinimumModal.ui.js'
 import ExchangeRate from '../../components/ExchangeRate/index.js'
 import { ExchangedFlipInput } from '../../components/FlipInput/ExchangedFlipInput2.js'
 import type { ExchangedFlipInputAmounts } from '../../components/FlipInput/ExchangedFlipInput2.js'
@@ -33,7 +34,8 @@ export type RequestStateProps = {
   receiveAddress: GuiReceiveAddress,
   secondaryCurrencyInfo: GuiCurrencyInfo,
   showToWalletModal: boolean,
-  useLegacyAddress: boolean
+  useLegacyAddress: boolean,
+  currentScene?: string
 }
 export type RequestLoadingProps = {
   edgeWallet: null,
@@ -45,7 +47,8 @@ export type RequestLoadingProps = {
   receiveAddress: null,
   secondaryCurrencyInfo: null,
   showToWalletModal: null,
-  useLegacyAddress: null
+  useLegacyAddress: null,
+  currentScene?: string
 }
 
 export type RequestDispatchProps = {
@@ -59,7 +62,9 @@ export type State = {
   publicAddress: string,
   legacyAddress: string,
   encodedURI: string,
-  result: string
+  result: string,
+  isXRPMinimumModalVisible: boolean,
+  hasXRPMinimumModalAlreadyShown: boolean
 }
 
 export class Request extends Component<Props, State> {
@@ -69,9 +74,17 @@ export class Request extends Component<Props, State> {
       publicAddress: '',
       legacyAddress: '',
       encodedURI: '',
-      result: ''
+      result: '',
+      isXRPMinimumModalVisible: false,
+      hasXRPMinimumModalAlreadyShown: false
     }
     slowlog(this, /.*/, global.slowlogOptions)
+  }
+
+  onCloseXRPMinimumModal = () => {
+    this.setState({
+      isXRPMinimumModalVisible: false
+    })
   }
 
   shouldComponentUpdate (nextProps: Props, nextState: State) {
@@ -109,6 +122,19 @@ export class Request extends Component<Props, State> {
         legacyAddress: legacyAddress
       })
     }
+    // old blank address to new
+    if (didWalletChange) {
+      if (nextProps.currencyCode === 'XRP') {
+        if (!this.state.hasXRPMinimumModalAlreadyShown) {
+          if (bns.lt(nextProps.guiWallet.primaryNativeBalance, '20')) {
+            this.setState({
+              isXRPMinimumModalVisible: true,
+              hasXRPMinimumModalAlreadyShown: true
+            })
+          }
+        }
+      }
+    }
   }
 
   render () {
@@ -123,6 +149,10 @@ export class Request extends Component<Props, State> {
     return (
       <SafeAreaView>
         <Gradient style={styles.view}>
+          <XRPMinimumModal
+            visibilityBoolean={this.state.isXRPMinimumModalVisible}
+            onExit={this.onCloseXRPMinimumModal}
+          />
           <Gradient style={styles.gradient} />
 
           <View style={styles.exchangeRateContainer}>

--- a/src/modules/UI/scenes/Request/Request.ui.js
+++ b/src/modules/UI/scenes/Request/Request.ui.js
@@ -34,8 +34,7 @@ export type RequestStateProps = {
   receiveAddress: GuiReceiveAddress,
   secondaryCurrencyInfo: GuiCurrencyInfo,
   showToWalletModal: boolean,
-  useLegacyAddress: boolean,
-  currentScene?: string
+  useLegacyAddress: boolean
 }
 export type RequestLoadingProps = {
   edgeWallet: null,
@@ -47,8 +46,7 @@ export type RequestLoadingProps = {
   receiveAddress: null,
   secondaryCurrencyInfo: null,
   showToWalletModal: null,
-  useLegacyAddress: null,
-  currentScene?: string
+  useLegacyAddress: null
 }
 
 export type RequestDispatchProps = {
@@ -126,7 +124,7 @@ export class Request extends Component<Props, State> {
     if (didWalletChange) {
       if (nextProps.currencyCode === 'XRP') {
         if (!this.state.hasXRPMinimumModalAlreadyShown) {
-          if (bns.lt(nextProps.guiWallet.primaryNativeBalance, '20')) {
+          if (bns.lt(nextProps.guiWallet.primaryNativeBalance, '20000000')) {
             this.setState({
               isXRPMinimumModalVisible: true,
               hasXRPMinimumModalAlreadyShown: true

--- a/src/modules/UI/scenes/Request/RequestConnector.js
+++ b/src/modules/UI/scenes/Request/RequestConnector.js
@@ -27,7 +27,8 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
       receiveAddress: null,
       secondaryCurrencyInfo: null,
       showToWalletModal: null,
-      useLegacyAddress: null
+      useLegacyAddress: null,
+      currentScene: state.ui.scenes.currentScene
     }
   }
 
@@ -65,7 +66,8 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
     receiveAddress: state.ui.scenes.request.receiveAddress,
     secondaryCurrencyInfo,
     showToWalletModal: state.ui.scenes.scan.scanToWalletListModalVisibility,
-    useLegacyAddress: state.ui.scenes.requestType.useLegacyAddress
+    useLegacyAddress: state.ui.scenes.requestType.useLegacyAddress,
+    currentScene: state.ui.scenes.currentScene
   }
 }
 const mapDispatchToProps = (dispatch: Dispatch): RequestDispatchProps => ({

--- a/src/modules/UI/scenes/Request/components/XRPMinimumModal/XRPMinimumModal.ui.js
+++ b/src/modules/UI/scenes/Request/components/XRPMinimumModal/XRPMinimumModal.ui.js
@@ -1,0 +1,46 @@
+// @flow
+
+import React, { Component } from 'react'
+import { Text } from 'react-native'
+import s from '../../../../../../locales/strings.js'
+import { InteractiveModal } from '../../../../components/Modals/InteractiveModal/InteractiveModal.ui.js'
+import {PrimaryButton} from '../../../../components/Modals/components/PrimaryButton.ui.js'
+import { Icon } from '../../../../components/Icon/Icon.ui.js'
+import { EXCLAMATION, MATERIAL_COMMUNITY } from '../../../../../../constants/IconConstants.js'
+
+type XRPMinimumModalStateProps = {
+  onExit(): void,
+  visibilityBoolean: boolean,
+}
+
+export default class XRPMinimumModal extends Component<XRPMinimumModalStateProps> {
+  render () {
+    return (
+
+      <InteractiveModal isActive={this.props.visibilityBoolean} onBackButtonPress={this.props.onExit} onBackdropPress={this.props.onExit} onModalHide={this.props.onExit}>
+        <InteractiveModal.Icon>
+          <Icon style={{}} type={MATERIAL_COMMUNITY} name={EXCLAMATION} size={30} />
+        </InteractiveModal.Icon>
+
+        <InteractiveModal.Title>
+          <Text>{s.strings.request_xrp_minimum_notification_title}</Text>
+        </InteractiveModal.Title>
+
+        <InteractiveModal.Body>
+          <InteractiveModal.Description style={{textAlign: 'center'}}>{s.strings.request_xrp_minimum_notification_body}</InteractiveModal.Description>
+        </InteractiveModal.Body>
+
+        <InteractiveModal.Footer>
+          <InteractiveModal.Row>
+            <InteractiveModal.Item>
+              <PrimaryButton onPress={this.props.onExit}>
+                <PrimaryButton.Text>{s.strings.string_ok}</PrimaryButton.Text>
+              </PrimaryButton>
+            </InteractiveModal.Item>
+          </InteractiveModal.Row>
+        </InteractiveModal.Footer>
+      </InteractiveModal>
+
+    )
+  }
+}

--- a/src/modules/UI/scenes/Request/components/XRPMinimumModal/XRPMinimumModal.ui.js
+++ b/src/modules/UI/scenes/Request/components/XRPMinimumModal/XRPMinimumModal.ui.js
@@ -23,7 +23,7 @@ export default class XRPMinimumModal extends Component<XRPMinimumModalStateProps
         </InteractiveModal.Icon>
 
         <InteractiveModal.Title>
-          <Text>{s.strings.request_xrp_minimum_notification_title}</Text>
+          <Text style={{textAlign: 'center'}}>{s.strings.request_xrp_minimum_notification_title}</Text>
         </InteractiveModal.Title>
 
         <InteractiveModal.Body>


### PR DESCRIPTION
The purpose of this task is to show a warning for XRP wallets that lets the user know that they need to have a minimum of 20 XRP before they can get increased functionality. A few notes:
1.) The modal should show up on the Request scene
2.) The modal should only show up if XRP is the selected wallet and the balance is less than 20 XRP
3.) The modal should only be shown either a.) once per session

Asana Task: https://app.asana.com/0/361770107085503/711646399708941