### PR TITLE
Fix mixup of comma vs period when entering decimal in FlipInput

### DIFF
--- a/src/locales/intl.js
+++ b/src/locales/intl.js
@@ -29,7 +29,7 @@ const intlHandler = {
   formatNumberInput (input: string, options?: IntlNumberFormatOptionsType): string {
     const _options = {}
 
-    if (input.endsWith('.')) {
+    if (input.endsWith('.') || input.endsWith(',')) {
       return intlHandler.formatNumber(input.slice(0, -1)) + locale.decimalSeparator
     }
     if (input.includes(NATIVE_DECIMAL_SEPARATOR)) {
@@ -76,10 +76,14 @@ const intlHandler = {
     const groupingSeparatorRegExp = new RegExp('\\' + groupingSeparator, 'g')
 
     if (value === decimalSeparator) return true
-    if (value === groupingSeparator || value.slice(-1) === groupingSeparator) return false
-    const standartized = value.replace(groupingSeparatorRegExp, '').replace(decimalSeparator, '.')
+    if (value.endsWith('.') || value.endsWith(',')) {
+      value = value.slice(0, -1) + locale.decimalSeparator
+    }
 
-    return !isNaN(+standartized)
+    // if (value === groupingSeparator || value.slice(-1) === groupingSeparator) return false
+    const standardized = value.replace(groupingSeparatorRegExp, '').replace(decimalSeparator, '.')
+
+    return !isNaN(+standardized)
   },
 
   /**
@@ -127,10 +131,13 @@ const intlHandler = {
    */
   formatToNativeNumber (value: string, options?: IntlNumberFormatOptionsType): string {
     const { decimalSeparator, groupingSeparator } = locale
+    if (value.endsWith('.') || value.endsWith(',')) {
+      value = value.slice(0, -1) + locale.decimalSeparator
+    }
     const groupingSeparatorRegExp = new RegExp('\\' + groupingSeparator, 'g')
-    const standartized = value.replace(groupingSeparatorRegExp, '').replace(decimalSeparator, '.')
+    const standardized = value.replace(groupingSeparatorRegExp, '').replace(decimalSeparator, '.')
 
-    return standartized
+    return standardized
   },
   // $FlowFixMe: add after implementation
   formatDate (date, options) {

--- a/src/locales/intl.test.js
+++ b/src/locales/intl.test.js
@@ -160,12 +160,12 @@ describe('Intl numbers', function () {
       beforeEach(() => {
         setIntlLocale(EN_US_LOCALE)
       })
-      test(',', function () {
-        expect(intl.isValidInput(',')).toBe(false)
-      })
-      test('de 1,', function () {
-        expect(intl.isValidInput('1,')).toBe(false)
-      })
+      // test(',', function () {
+      //   expect(intl.isValidInput(',')).toBe(false)
+      // })
+      // test('de 1,', function () {
+      //   expect(intl.isValidInput('1,')).toBe(false)
+      // })
     })
   })
 


### PR DESCRIPTION
Accept either comma or period as decimal separator and simply convert it to the current locale decimal separator no matter what. Fixes inability to enter a decimal when region doesn't match language.