### PR TITLE
Removal of IMP currency (no exchange rate)

### DIFF
--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -73,7 +73,6 @@ export const FIAT_CODES_SYMBOLS = {
   HUF: 'Ft',
   IDR: 'Rp',
   ILS: '₪',
-  IMP: '£',
   INR: '₹',
   IQD: 'ع.د',
   IRR: '﷼',


### PR DESCRIPTION
The purpose of this task is to remove the Isle of Man Pound (IMP) currency from the list of fiats because it does not have any exchange rate.

Asana Task: https://app.asana.com/0/361770107085503/718202392108831