### PR TITLE
Wait for address before displaying to user in Request scene

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "edge-core-js": "0.9.6",
     "edge-currency-bitcoin": "2.21.1",
     "edge-currency-ethereum": "0.10.2",
-    "edge-currency-monero": "^0.0.7",
+    "edge-currency-monero": "^0.0.8",
     "edge-currency-ripple": "^0.0.6",
     "edge-exchange-plugins": "^0.2.0",
     "edge-login-ui-rn": "^0.3.3",

--- a/src/modules/UI/scenes/Request/RequestConnector.js
+++ b/src/modules/UI/scenes/Request/RequestConnector.js
@@ -12,6 +12,7 @@ import * as SETTINGS_SELECTORS from '../../Settings/selectors.js'
 import { saveReceiveAddress } from './action.js'
 import { Request } from './Request.ui'
 import type { RequestDispatchProps, RequestLoadingProps, RequestStateProps } from './Request.ui'
+import {refreshReceiveAddressRequest} from '../../Wallets/action'
 
 const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps => {
   const guiWallet: GuiWallet = UI_SELECTORS.getSelectedWallet(state)
@@ -73,6 +74,9 @@ const mapStateToProps = (state: State): RequestStateProps | RequestLoadingProps 
 const mapDispatchToProps = (dispatch: Dispatch): RequestDispatchProps => ({
   saveReceiveAddress: (receiveAddress: GuiReceiveAddress) => {
     dispatch(saveReceiveAddress(receiveAddress))
+  },
+  refreshReceiveAddressRequest: (walletId) => {
+    dispatch(refreshReceiveAddressRequest(walletId))
   }
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,9 +2416,9 @@ edge-currency-ethereum@0.10.2:
     sprintf-js "^1.1.1"
     uri-js "^3.0.2"
 
-edge-currency-monero@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/edge-currency-monero/-/edge-currency-monero-0.0.7.tgz#502938cbb4ab5733e9f54f934967465c480c1b80"
+edge-currency-monero@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/edge-currency-monero/-/edge-currency-monero-0.0.8.tgz#c7c83b3c1672a583b9980fab0c427f8ff2bc1542"
   dependencies:
     biggystring "^3.0.0"
     buffer "^5.0.6"


### PR DESCRIPTION
With new update to Monero library, getReceiveAddress may return a blank string when wallet is first created. This change is required to fully fix issues with users' accounts not getting indexed by MyMonero service in time to receive early transactions.

* Bump Monero library
* Make sure to catch error in encodeUri due to invalid public address
* If Request scene detects an invalid address, wait 2 seconds and then refresh the public address