### PR TITLE
Change password reminder stepoff to 4x vs 2x

### DIFF
--- a/src/modules/Core/Account/settings.js
+++ b/src/modules/Core/Account/settings.js
@@ -42,8 +42,8 @@ export const LOCAL_ACCOUNT_DEFAULTS = {
     lastPasswordUseDate: 0,
     passwordUseCount: 0,
     nonPasswordLoginsCount: 0,
-    nonPasswordDaysLimit: 2,
-    nonPasswordLoginsLimit: 2
+    nonPasswordDaysLimit: 4,
+    nonPasswordLoginsLimit: 4
   }
 }
 

--- a/src/reducers/passwordReminder/passwordReminderReducer.js
+++ b/src/reducers/passwordReminder/passwordReminderReducer.js
@@ -14,8 +14,8 @@ export const INITIAL_NON_PASSWORD_LOGINS_LIMIT = 2
 export const MAX_NON_PASSWORD_DAYS_LIMIT = 64 // max number of consecutive non password days
 export const MAX_NON_PASSWORD_LOGINS_LIMIT = 128 // max number of consecutive non password logins
 
-export const NON_PASSWORD_DAYS_GROWTH_RATE = 2
-export const NON_PASSWORD_LOGINS_GROWTH_RATE = 2
+export const NON_PASSWORD_DAYS_GROWTH_RATE = 4
+export const NON_PASSWORD_LOGINS_GROWTH_RATE = 4
 
 export const NON_PASSWORD_DAYS_POSTPONEMENT = 2
 export const NON_PASSWORD_LOGINS_POSTPONEMENT = 2

--- a/src/reducers/passwordReminder/passwordReminderReducer.test.js
+++ b/src/reducers/passwordReminder/passwordReminderReducer.test.js
@@ -88,8 +88,8 @@ describe('PasswordReminder', () => {
         const needsPasswordCheck = false
         const lastPasswordUseDate = testDate
         const passwordUseCount = 1
-        const nonPasswordDaysLimit = 2
-        const nonPasswordLoginsLimit = 2
+        const nonPasswordDaysLimit = 4
+        const nonPasswordLoginsLimit = 4
 
         const expected = {
           ...initialState,


### PR DESCRIPTION
Some user's have been complaining that the reminders are too frequent even after they've entered the password a couple times. This backs it off by double.