### PR TITLE
Adjust 5-character currencyCode limit to 6

### DIFF
--- a/src/constants/WalletAndCurrencyConstants.js
+++ b/src/constants/WalletAndCurrencyConstants.js
@@ -3,6 +3,7 @@
 export const ETHEREUM_WALLET = 'wallet:ethereum'
 export const BITCOIN_WALLET = 'wallet:bitcoin-bip49'
 export const BITCOINCASH_WALLET = 'wallet:bitcoincash-bip44'
+export const MAX_TOKEN_CODE_CHARACTERS = 6
 
 export const USD_FIAT = 'iso:USD'
 export const getSymbolFromCurrency = (currencyCode: string) => {

--- a/src/modules/UI/scenes/AddToken/AddToken.ui.js
+++ b/src/modules/UI/scenes/AddToken/AddToken.ui.js
@@ -14,6 +14,7 @@ import Text from '../../components/FormattedText'
 import Gradient from '../../components/Gradient/Gradient.ui'
 import SafeAreaView from '../../components/SafeAreaView'
 import styles from './style.js'
+import * as Constants from '../../../../constants/indexConstants.js'
 
 export type AddTokenOwnProps = {
   walletId: string,
@@ -93,7 +94,7 @@ export class AddToken extends Component<AddTokenProps, State> {
                   label={s.strings.addtoken_currency_code_input_text}
                   returnKeyType={'done'}
                   autoCorrect={false}
-                  maxLength={5}
+                  maxLength={Constants.MAX_TOKEN_CODE_CHARACTERS}
                 />
               </View>
               <View style={[styles.contractAddressArea]}>

--- a/src/modules/UI/scenes/EditToken/EditToken.ui.js
+++ b/src/modules/UI/scenes/EditToken/EditToken.ui.js
@@ -125,7 +125,7 @@ export default class EditToken extends Component<EditTokenComponentProps, State>
                   label={s.strings.addtoken_currency_code_input_text}
                   returnKeyType={'done'}
                   autoCorrect={false}
-                  maxLength={5}
+                  maxLength={Constants.MAX_TOKEN_CODE_CHARACTERS}
                 />
               </View>
               <View style={[styles.contractAddressArea]}>


### PR DESCRIPTION
The purpose of this task is to allow the users to assign a 6-digit (previous 5-digit) currencyCode to custom tokens.

Asana Task: https://app.asana.com/0/361770107085503/735637907328392/f